### PR TITLE
MM-27032 Confirm stage removal.

### DIFF
--- a/webapp/src/components/backstage/stage_edit.tsx
+++ b/webapp/src/components/backstage/stage_edit.tsx
@@ -32,7 +32,6 @@ interface Props {
     checklist: Checklist;
     checklistIndex: number;
     onChange: (checklist: Checklist) => void;
-    onRemove: () => void;
 }
 
 export const StageEditor = (props: Props): React.ReactElement => {

--- a/webapp/src/components/backstage/stages_and_steps_edit.tsx
+++ b/webapp/src/components/backstage/stages_and_steps_edit.tsx
@@ -38,7 +38,7 @@ interface Props {
 }
 
 export const StagesAndStepsEdit = (props: Props): React.ReactElement => {
-    const [confirmRemoveChecklist, setConfirmRemoveChecklist] = useState({open: false, stage: 0});
+    const [confirmRemoveChecklistNum, setConfirmRemoveChecklistNum] = useState(-1);
 
     const onDragEnd = (result: DropResult) => {
         if (!result.destination) {
@@ -134,7 +134,7 @@ export const StagesAndStepsEdit = (props: Props): React.ReactElement => {
         if (filteredChecklistItems.length === 0) {
             onRemoveChecklist(checklistIndex);
         } else {
-            setConfirmRemoveChecklist({open: true, stage: checklistIndex});
+            setConfirmRemoveChecklistNum(checklistIndex);
         }
     };
 
@@ -187,15 +187,15 @@ export const StagesAndStepsEdit = (props: Props): React.ReactElement => {
                 </HorizontalBar>
             </NewStageContainer>
             <ConfirmModal
-                show={confirmRemoveChecklist.open}
+                show={confirmRemoveChecklistNum >= 0}
                 title={'Remove Stage'}
                 message={'Are you sere you want to remove the stage? All steps will be removed.'}
                 confirmButtonText={'Remove Stage'}
                 onConfirm={() => {
-                    onRemoveChecklist(confirmRemoveChecklist.stage);
-                    setConfirmRemoveChecklist({open: false, stage: 0});
+                    onRemoveChecklist(confirmRemoveChecklistNum);
+                    setConfirmRemoveChecklistNum(-1);
                 }}
-                onCancel={() => setConfirmRemoveChecklist({open: false, stage: 0})}
+                onCancel={() => setConfirmRemoveChecklistNum(-1)}
             />
         </DragDropContext>
     );


### PR DESCRIPTION
#### Summary
Adds a confirmation modal for stage removal.
Does not implement the custom modal for moving all the steps to another stage as this would involve even more custom UI for little benefit. Also unlike the design, it will actually allow you to delete a stage like you intended to do when you clicked delete on it. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27032

