### PR TITLE
MM-27002: Playbook sql store

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - scopelint
     - staticcheck

--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -829,7 +829,7 @@ func (h *IncidentHandler) postIncidentCreatedMessage(incdnt *incident.Incident, 
 	return nil
 }
 
-// parseIncidentsFilterOptions is only for parsing. Put validation logic in service.validateOptions.
+// parseIncidentsFilterOptions is only for parsing. Put validation logic in incident.validateOptions.
 func parseIncidentsFilterOptions(u *url.URL) (*incident.HeaderFilterOptions, error) {
 	teamID := u.Query().Get("team_id")
 

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -185,7 +185,7 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 	userID := r.Header.Get("Mattermost-User-ID")
 	opts, page, perPage, err := parseGetPlaybooksOptions(r.URL)
 	if err != nil {
-		HandleError(w, errors.Wrap(err, "failed to parse playbook options"))
+		HandleError(w, err)
 		return
 	}
 
@@ -262,24 +262,24 @@ func parseGetPlaybooksOptions(u *url.URL) (opts playbook.Options, page, perPage 
 	param := strings.ToLower(params.Get("sort"))
 	switch param {
 	case "title", "":
-		sortField = playbook.Title
+		sortField = playbook.SortByTitle
 	case "stages":
-		sortField = playbook.Stages
+		sortField = playbook.SortByStages
 	case "steps":
-		sortField = playbook.Steps
+		sortField = playbook.SortBySteps
 	default:
-		sortField = playbook.SortField(param)
+		return playbook.Options{}, 0, 0, errors.Errorf("bad parameter 'sort' (%s): it should be empty or one of 'title', 'stages' or 'steps'", param)
 	}
 
 	var sortDirection playbook.SortDirection
 	param = strings.ToLower(params.Get("direction"))
 	switch param {
 	case "asc", "":
-		sortDirection = playbook.Asc
+		sortDirection = playbook.OrderAsc
 	case "desc":
-		sortDirection = playbook.Desc
+		sortDirection = playbook.OrderDesc
 	default:
-		sortDirection = playbook.SortDirection(param)
+		return playbook.Options{}, 0, 0, errors.Errorf("bad parameter 'direction' (%s): it should be empty or one of 'asc' or 'desc'", param)
 	}
 
 	pageParam := params.Get("page")

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-plugin-incident-response/server/bot"
@@ -257,14 +258,28 @@ func (h *PlaybookHandler) hasPermissionsToPlaybook(thePlaybook playbook.Playbook
 func parseGetPlaybooksOptions(u *url.URL) (opts playbook.Options, page, perPage int, err error) {
 	params := u.Query()
 
-	sortField := playbook.SortField(params.Get("sort"))
-	if sortField == "" {
+	var sortField playbook.SortField
+	param := strings.ToLower(params.Get("sort"))
+	switch param {
+	case "title", "":
 		sortField = playbook.Title
+	case "stages":
+		sortField = playbook.Stages
+	case "steps":
+		sortField = playbook.Steps
+	default:
+		sortField = playbook.SortField(param)
 	}
 
-	sortDirection := playbook.SortDirection(params.Get("direction"))
-	if sortDirection == "" {
+	var sortDirection playbook.SortDirection
+	param = strings.ToLower(params.Get("direction"))
+	switch param {
+	case "asc", "":
 		sortDirection = playbook.Asc
+	case "desc":
+		sortDirection = playbook.Desc
+	default:
+		sortDirection = playbook.SortDirection(param)
 	}
 
 	pageParam := params.Get("page")

--- a/server/api/playbooks_test.go
+++ b/server/api/playbooks_test.go
@@ -659,14 +659,14 @@ func TestSortingPlaybooks(t *testing.T) {
 			sortField:     "test",
 			sortDirection: "",
 			expectedList:  nil,
-			expectedErr:   errors.New("invalid sort field test"),
+			expectedErr:   errors.New("bad parameter 'sort' (test)"),
 		},
 		{
 			testName:      "get playbooks with invalid sort direction",
 			sortField:     "",
 			sortDirection: "test",
 			expectedList:  nil,
-			expectedErr:   errors.New("invalid sort direction test"),
+			expectedErr:   errors.New("bad parameter 'direction' (test)"),
 		},
 		{
 			testName:      "get playbooks with no sort fields",

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -122,7 +122,7 @@ func (r *Runner) actionStart(args []string) {
 		postID = args[1]
 	}
 
-	playbooks, err := r.playbookService.GetPlaybooksForTeam(r.args.TeamId, playbook.Options{Sort: playbook.Title, Direction: playbook.Asc})
+	playbooks, err := r.playbookService.GetPlaybooksForTeam(r.args.TeamId, playbook.Options{Sort: playbook.SortByTitle, Direction: playbook.OrderAsc})
 	if err != nil {
 		r.postCommandResponse(fmt.Sprintf("Error: %v", err))
 		return

--- a/server/playbook/filter_options.go
+++ b/server/playbook/filter_options.go
@@ -1,0 +1,47 @@
+package playbook
+
+// SortField enumerates the available fields we can sort on.
+type SortField string
+
+const (
+	// Title sorts by the "Title" field.
+	SortByTitle SortField = "Title"
+
+	// Stages sorts by the number of checklists in a playbook.
+	SortByStages SortField = "Stages"
+
+	// Steps sorts by the the number of steps in a playbook.
+	SortBySteps SortField = "Steps"
+)
+
+// SortDirection is the type used to specify the ascending or descending order of returned results.
+type SortDirection string
+
+const (
+	// Desc is descending order.
+	OrderDesc SortDirection = "DESC"
+
+	// Asc is ascending order.
+	OrderAsc SortDirection = "ASC"
+)
+
+// Options specifies the parameters when getting playbooks.
+type Options struct {
+	Sort      SortField
+	Direction SortDirection
+}
+
+func IsValidSortBy(sortBy SortField) bool {
+	switch sortBy {
+	case SortByTitle,
+		SortByStages,
+		SortBySteps:
+		return true
+	}
+
+	return false
+}
+
+func IsValidOrderBy(orderBy SortDirection) bool {
+	return orderBy == OrderAsc || orderBy == OrderDesc
+}

--- a/server/playbook/playbook.go
+++ b/server/playbook/playbook.go
@@ -13,18 +13,22 @@ type Playbook struct {
 	Title                string      `json:"title"`
 	TeamID               string      `json:"team_id"`
 	CreatePublicIncident bool        `json:"create_public_incident"`
+	CreateAt             int64       `json:"create_at"`
+	DeleteAt             int64       `json:"delete_at"`
 	Checklists           []Checklist `json:"checklists"`
 	MemberIDs            []string    `json:"member_ids"`
 }
 
 // Checklist represents a checklist in a playbook
 type Checklist struct {
+	ID    string          `json:"id"`
 	Title string          `json:"title"`
 	Items []ChecklistItem `json:"items"`
 }
 
 // ChecklistItem represents an item in a checklist
 type ChecklistItem struct {
+	ID                     string `json:"id"`
 	Title                  string `json:"title"`
 	State                  string `json:"state"`
 	StateModified          int64  `json:"state_modified"`
@@ -40,14 +44,14 @@ type ChecklistItem struct {
 type SortField string
 
 const (
-	// Title sorts by the "title" field.
-	Title SortField = "title"
+	// Title sorts by the "Title" field.
+	Title SortField = "Title"
 
 	// Stages sorts by the number of checklists in a playbook.
-	Stages SortField = "stages"
+	Stages SortField = "Stages"
 
 	// Steps sorts by the the number of steps in a playbook.
-	Steps SortField = "steps"
+	Steps SortField = "Steps"
 )
 
 // SortDirection is the type used to specify the ascending or descending order of returned results.
@@ -55,10 +59,10 @@ type SortDirection string
 
 const (
 	// Desc is descending order.
-	Desc SortDirection = "desc"
+	Desc SortDirection = "DESC"
 
 	// Asc is ascending order.
-	Asc SortDirection = "asc"
+	Asc SortDirection = "ASC"
 )
 
 // Options specifies the parameters when getting playbooks.
@@ -75,7 +79,7 @@ type Service interface {
 	Create(playbook Playbook) (string, error)
 	// GetPlaybooks retrieves all playbooks
 	GetPlaybooks() ([]Playbook, error)
-	// GetPlaybooksForTeam retrieves all playbooks on the specified team
+	// GetPlaybooksForTeam retrieves all playbooks on the specified team given the provided options
 	GetPlaybooksForTeam(teamID string, opts Options) ([]Playbook, error)
 	// Update updates a playbook
 	Update(playbook Playbook) error
@@ -91,6 +95,8 @@ type Store interface {
 	Create(playbook Playbook) (string, error)
 	// GetPlaybooks retrieves all playbooks
 	GetPlaybooks() ([]Playbook, error)
+	// GetPlaybooksForTeam retrieves all playbooks on the specified team
+	GetPlaybooksForTeam(teamID string, opts Options) ([]Playbook, error)
 	// Update updates a playbook
 	Update(playbook Playbook) error
 	// Delete deletes a playbook

--- a/server/playbook/playbook.go
+++ b/server/playbook/playbook.go
@@ -40,37 +40,6 @@ type ChecklistItem struct {
 	Description            string `json:"description"`
 }
 
-// SortField enumerates the available fields we can sort on.
-type SortField string
-
-const (
-	// Title sorts by the "Title" field.
-	Title SortField = "Title"
-
-	// Stages sorts by the number of checklists in a playbook.
-	Stages SortField = "Stages"
-
-	// Steps sorts by the the number of steps in a playbook.
-	Steps SortField = "Steps"
-)
-
-// SortDirection is the type used to specify the ascending or descending order of returned results.
-type SortDirection string
-
-const (
-	// Desc is descending order.
-	Desc SortDirection = "DESC"
-
-	// Asc is ascending order.
-	Asc SortDirection = "ASC"
-)
-
-// Options specifies the parameters when getting playbooks.
-type Options struct {
-	Sort      SortField
-	Direction SortDirection
-}
-
 // Service is the playbook service for managing playbooks
 type Service interface {
 	// Get retrieves a playbook. Returns ErrNotFound if not found.

--- a/server/playbook/service.go
+++ b/server/playbook/service.go
@@ -1,8 +1,6 @@
 package playbook
 
 import (
-	"sort"
-
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-plugin-incident-response/server/bot"
@@ -44,23 +42,7 @@ func (s *service) GetPlaybooks() ([]Playbook, error) {
 }
 
 func (s *service) GetPlaybooksForTeam(teamID string, opts Options) ([]Playbook, error) {
-	playbooks, err := s.store.GetPlaybooks()
-	if err != nil {
-		return nil, err
-	}
-
-	teamPlaybooks := make([]Playbook, 0, len(playbooks))
-	for _, playbook := range playbooks {
-		if playbook.TeamID == teamID {
-			teamPlaybooks = append(teamPlaybooks, playbook)
-		}
-	}
-
-	if err := sortPlaybooks(teamPlaybooks, opts); err != nil {
-		return nil, err
-	}
-
-	return teamPlaybooks, nil
+	return s.store.GetPlaybooksForTeam(teamID, opts)
 }
 
 func (s *service) Update(playbook Playbook) error {
@@ -85,47 +67,4 @@ func (s *service) Delete(playbook Playbook) error {
 	s.telemetry.DeletePlaybook(playbook)
 
 	return nil
-}
-
-func sortPlaybooks(playbooks []Playbook, opts Options) error {
-	var sortDirectionFn func(b bool) bool
-	switch opts.Direction {
-	case Asc:
-		sortDirectionFn = func(b bool) bool { return !b }
-	case Desc:
-		sortDirectionFn = func(b bool) bool { return b }
-	default:
-		return errors.Errorf("invalid sort direction %s", opts.Direction)
-	}
-
-	var sortFn func(i, j int) bool
-	switch opts.Sort {
-	case Title:
-		sortFn = func(i, j int) bool {
-			return sortDirectionFn(playbooks[i].Title > playbooks[j].Title)
-		}
-	case Stages:
-		sortFn = func(i, j int) bool {
-			return sortDirectionFn(len(playbooks[i].Checklists) > len(playbooks[j].Checklists))
-		}
-	case Steps:
-		sortFn = func(i, j int) bool {
-			stepsI := getSteps(playbooks[i])
-			stepsJ := getSteps(playbooks[j])
-			return sortDirectionFn(stepsI > stepsJ)
-		}
-	default:
-		return errors.Errorf("invalid sort field %s", opts.Sort)
-	}
-
-	sort.Slice(playbooks, sortFn)
-	return nil
-}
-
-func getSteps(playbook Playbook) int {
-	steps := 0
-	for _, p := range playbook.Checklists {
-		steps += len(p.Items)
-	}
-	return steps
 }

--- a/server/pluginkvstore/playbook_store.go
+++ b/server/pluginkvstore/playbook_store.go
@@ -2,6 +2,7 @@ package pluginkvstore
 
 import (
 	"encoding/json"
+	"sort"
 
 	"github.com/pkg/errors"
 
@@ -162,6 +163,27 @@ func (p *PlaybookStore) GetPlaybooks() ([]playbook.Playbook, error) {
 	return playbooks, nil
 }
 
+// GetPlaybooksForTeam retrieves all playbooks on the specified team given the provided options
+func (p *PlaybookStore) GetPlaybooksForTeam(teamID string, opts playbook.Options) ([]playbook.Playbook, error) {
+	playbooks, err := p.GetPlaybooks()
+	if err != nil {
+		return nil, err
+	}
+
+	teamPlaybooks := make([]playbook.Playbook, 0, len(playbooks))
+	for _, playbook := range playbooks {
+		if playbook.TeamID == teamID {
+			teamPlaybooks = append(teamPlaybooks, playbook)
+		}
+	}
+
+	if err := sortPlaybooks(teamPlaybooks, opts); err != nil {
+		return nil, err
+	}
+
+	return teamPlaybooks, nil
+}
+
 // Update updates a playbook
 func (p *PlaybookStore) Update(updated playbook.Playbook) error {
 	if updated.ID == "" {
@@ -193,4 +215,47 @@ func (p *PlaybookStore) Delete(id string) error {
 	}
 
 	return nil
+}
+
+func sortPlaybooks(playbooks []playbook.Playbook, opts playbook.Options) error {
+	var sortDirectionFn func(b bool) bool
+	switch opts.Direction {
+	case playbook.Asc:
+		sortDirectionFn = func(b bool) bool { return !b }
+	case playbook.Desc:
+		sortDirectionFn = func(b bool) bool { return b }
+	default:
+		return errors.Errorf("invalid sort direction %s", opts.Direction)
+	}
+
+	var sortFn func(i, j int) bool
+	switch opts.Sort {
+	case playbook.Title:
+		sortFn = func(i, j int) bool {
+			return sortDirectionFn(playbooks[i].Title > playbooks[j].Title)
+		}
+	case playbook.Stages:
+		sortFn = func(i, j int) bool {
+			return sortDirectionFn(len(playbooks[i].Checklists) > len(playbooks[j].Checklists))
+		}
+	case playbook.Steps:
+		sortFn = func(i, j int) bool {
+			stepsI := getSteps(playbooks[i])
+			stepsJ := getSteps(playbooks[j])
+			return sortDirectionFn(stepsI > stepsJ)
+		}
+	default:
+		return errors.Errorf("invalid sort field %s", opts.Sort)
+	}
+
+	sort.Slice(playbooks, sortFn)
+	return nil
+}
+
+func getSteps(pbook playbook.Playbook) int {
+	steps := 0
+	for _, p := range pbook.Checklists {
+		steps += len(p.Items)
+	}
+	return steps
 }

--- a/server/pluginkvstore/playbook_store.go
+++ b/server/pluginkvstore/playbook_store.go
@@ -220,9 +220,9 @@ func (p *PlaybookStore) Delete(id string) error {
 func sortPlaybooks(playbooks []playbook.Playbook, opts playbook.Options) error {
 	var sortDirectionFn func(b bool) bool
 	switch opts.Direction {
-	case playbook.Asc:
+	case playbook.OrderAsc:
 		sortDirectionFn = func(b bool) bool { return !b }
-	case playbook.Desc:
+	case playbook.OrderDesc:
 		sortDirectionFn = func(b bool) bool { return b }
 	default:
 		return errors.Errorf("invalid sort direction %s", opts.Direction)
@@ -230,15 +230,15 @@ func sortPlaybooks(playbooks []playbook.Playbook, opts playbook.Options) error {
 
 	var sortFn func(i, j int) bool
 	switch opts.Sort {
-	case playbook.Title:
+	case playbook.SortByTitle:
 		sortFn = func(i, j int) bool {
 			return sortDirectionFn(playbooks[i].Title > playbooks[j].Title)
 		}
-	case playbook.Stages:
+	case playbook.SortByStages:
 		sortFn = func(i, j int) bool {
 			return sortDirectionFn(len(playbooks[i].Checklists) > len(playbooks[j].Checklists))
 		}
-	case playbook.Steps:
+	case playbook.SortBySteps:
 		sortFn = func(i, j int) bool {
 			stepsI := getSteps(playbooks[i])
 			stepsJ := getSteps(playbooks[j])

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -39,7 +39,7 @@ func NewPlaybookStore(pluginAPI PluginAPIClient, log bot.Logger, sqlStore *SQLSt
 
 	playbookSelect := builder.
 		Select("ID", "Title", "TeamID", "CreatePublicIncident", "CreateAt",
-			"DeleteAt", "ChecklistJSON", "Stages", "Steps").
+			"DeleteAt", "ChecklistJSON").
 		From("IR_Playbook")
 
 	memberIDsSelect := builder.

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -1,0 +1,338 @@
+package sqlstore
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/mattermost/mattermost-plugin-incident-response/server/bot"
+	"github.com/mattermost/mattermost-plugin-incident-response/server/playbook"
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/pkg/errors"
+)
+
+// playbookStore is a sql store for playbooks. DO NO USE DIRECTLY Use NewPlaybookStore
+type playbookStore struct {
+	pluginAPI       PluginAPIClient
+	log             bot.Logger
+	store           *SQLStore
+	queryBuilder    sq.StatementBuilderType
+	playbookSelect  sq.SelectBuilder
+	memberIDsSelect sq.SelectBuilder
+}
+
+// Ensure playbookStore implements the playbook.Store interface.
+var _ playbook.Store = (*playbookStore)(nil)
+
+type playbookMembers []struct {
+	PlaybookID string
+	MemberID   string
+}
+
+// NewPlaybookStore creates a new store for playbook service.
+func NewPlaybookStore(pluginAPI PluginAPIClient, log bot.Logger, sqlStore *SQLStore) playbook.Store {
+	builder := sq.StatementBuilder.PlaceholderFormat(sq.Question)
+	if pluginAPI.Store.DriverName() == model.DATABASE_DRIVER_POSTGRES {
+		builder = builder.PlaceholderFormat(sq.Dollar)
+	}
+
+	playbookSelect := builder.
+		Select("ID", "Title", "TeamID", "CreatePublicIncident", "CreateAt",
+			"DeleteAt", "ChecklistJSON").
+		From("IR_Playbook")
+
+	memberIDsSelect := builder.
+		Select("PlaybookID", "MemberID").
+		From("IR_PlaybookMember")
+
+	newStore := &playbookStore{
+		pluginAPI:       pluginAPI,
+		log:             log,
+		store:           sqlStore,
+		queryBuilder:    builder,
+		playbookSelect:  playbookSelect,
+		memberIDsSelect: memberIDsSelect,
+	}
+	return newStore
+}
+
+// Create creates a new playbook
+func (p *playbookStore) Create(pbook playbook.Playbook) (id string, err error) {
+	pbook.ID = model.NewId()
+
+	checklistsJSON, err := checklistsToJSON(pbook)
+	if err != nil {
+		return "", err
+	}
+
+	// Beginning a transaction because we're doing multiple statements and need a consistent view of the db.
+	tx, err := p.store.db.Beginx()
+	if err != nil {
+		return "", errors.Wrap(err, "could not begin transaction")
+	}
+	defer func() {
+		cerr := tx.Rollback()
+		if err == nil && cerr != sql.ErrTxDone {
+			err = cerr
+		}
+	}()
+
+	err = p.store.execBuilder(tx, sq.
+		Insert("IR_Playbook").
+		SetMap(map[string]interface{}{
+			"ID":                   pbook.ID,
+			"Title":                pbook.Title,
+			"TeamID":               pbook.TeamID,
+			"CreatePublicIncident": pbook.CreatePublicIncident,
+			"CreateAt":             model.GetMillis(),
+			"DeleteAt":             0,
+			"ChecklistsJSON":       checklistsJSON,
+		}))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to store new playbook")
+	}
+
+	if err = p.replacePlaybookMembers(tx, pbook); err != nil {
+		return "", errors.Wrap(err, "failed to replace playbook members")
+	}
+
+	if err = tx.Commit(); err != nil {
+		return "", errors.Wrap(err, "could not commit transaction")
+	}
+
+	return pbook.ID, nil
+}
+
+// Get retrieves a playbook
+func (p *playbookStore) Get(id string) (out playbook.Playbook, err error) {
+	if id == "" {
+		return out, errors.New("ID cannot be empty")
+	}
+
+	// Beginning a transaction because we're doing multiple selects and need a consistent view of the db.
+	tx, err := p.store.db.Beginx()
+	if err != nil {
+		return out, errors.Wrap(err, "could not begin transaction")
+	}
+	defer func() {
+		cerr := tx.Rollback()
+		if err == nil && cerr != sql.ErrTxDone {
+			err = cerr
+		}
+	}()
+
+	err = p.store.getBuilder(tx, &out, p.playbookSelect.Where(sq.Eq{"ID": id}))
+	if err == sql.ErrNoRows {
+		return out, errors.Wrapf(playbook.ErrNotFound, "playbook with does not exist for id '%s'", id)
+	} else if err != nil {
+		return out, errors.Wrapf(err, "failed to get playbook by id '%s'", id)
+	}
+
+	var memberIDs playbookMembers
+	err = p.store.selectBuilder(tx, &memberIDs, p.memberIDsSelect.Where(sq.Eq{"PlaybookID": id}))
+	if err != nil && err != sql.ErrNoRows {
+		return out, errors.Wrapf(err, "failed to get memberIDs for playbook with id '%s'", id)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return out, errors.Wrap(err, "could not commit transaction")
+	}
+
+	for _, m := range memberIDs {
+		out.MemberIDs = append(out.MemberIDs, m.MemberID)
+	}
+
+	return out, nil
+}
+
+// GetPlaybooks retrieves all playbooks that are not deleted.
+func (p *playbookStore) GetPlaybooks() (out []playbook.Playbook, err error) {
+	// Beginning a transaction because we're doing multiple selects and need a consistent view of the db.
+	tx, err := p.store.db.Beginx()
+	if err != nil {
+		return out, errors.Wrap(err, "could not begin transaction")
+	}
+	defer func() {
+		cerr := tx.Rollback()
+		if err == nil && cerr != sql.ErrTxDone {
+			err = cerr
+		}
+	}()
+
+	err = p.store.selectBuilder(tx, &out, p.playbookSelect.Where(sq.Eq{"DeleteAt": 0}))
+	if err == sql.ErrNoRows {
+		return out, errors.Wrap(playbook.ErrNotFound, "no playbooks found")
+	} else if err != nil {
+		return out, errors.Wrap(err, "failed to get playbooks")
+	}
+
+	var memberIDs playbookMembers
+	err = p.store.selectBuilder(tx, &memberIDs, p.memberIDsSelect)
+	if err != nil && err != sql.ErrNoRows {
+		return out, errors.Wrapf(err, "failed to get memberIDs")
+	}
+
+	if err = tx.Commit(); err != nil {
+		return out, errors.Wrap(err, "could not commit transaction")
+	}
+
+	addMembersToPlaybooks(memberIDs, out)
+
+	return out, nil
+}
+
+// GetPlaybooksForTeam retrieves all playbooks on the specified team given the provided options
+func (p *playbookStore) GetPlaybooksForTeam(teamID string, opts playbook.Options) (out []playbook.Playbook, err error) {
+	// Beginning a transaction because we're doing multiple selects and need a consistent view of the db.
+	tx, err := p.store.db.Beginx()
+	if err != nil {
+		return out, errors.Wrap(err, "could not begin transaction")
+	}
+	defer func() {
+		cerr := tx.Rollback()
+		if err == nil && cerr != sql.ErrTxDone {
+			err = cerr
+		}
+	}()
+
+	query := p.playbookSelect.
+		Where(sq.Eq{"DeleteAt": 0}).
+		Where(sq.Eq{"TeamID": teamID}).
+		OrderBy(fmt.Sprintf("%s %s", opts.Sort, opts.Direction))
+
+	err = p.store.selectBuilder(tx, &out, query)
+	if err == sql.ErrNoRows {
+		return out, errors.Wrap(playbook.ErrNotFound, "no playbooks found")
+	} else if err != nil {
+		return out, errors.Wrap(err, "failed to get playbooks")
+	}
+
+	nestedQuery := p.queryBuilder.
+		Select("ID").
+		From("IR_Playbook").
+		Where(sq.Eq{"DeleteAt": 0}).
+		Where(sq.Eq{"TeamID": teamID})
+
+	// TODO: Alejandro, this should work, but I'm eyeballing it:
+	// And this is why SQL is awesome
+	query = p.memberIDsSelect.Where(nestedQuery.Prefix("PlaybookID IN (").Suffix(")"))
+
+	var memberIDs playbookMembers
+	err = p.store.selectBuilder(tx, &memberIDs, query)
+	if err != nil && err != sql.ErrNoRows {
+		return out, errors.Wrapf(err, "failed to get memberIDs")
+	}
+
+	if err = tx.Commit(); err != nil {
+		return out, errors.Wrap(err, "could not commit transaction")
+	}
+
+	addMembersToPlaybooks(memberIDs, out)
+
+	return out, nil
+}
+
+// Update updates a playbook
+func (p *playbookStore) Update(updated playbook.Playbook) (err error) {
+	if updated.ID == "" {
+		return errors.New("updating playbook without ID")
+	}
+
+	checklistsJSON, err := checklistsToJSON(updated)
+	if err != nil {
+		return err
+	}
+
+	// Beginning a transaction because we're doing multiple statements and need a consistent view of the db.
+	tx, err := p.store.db.Beginx()
+	if err != nil {
+		return errors.Wrap(err, "could not begin transaction")
+	}
+	defer func() {
+		cerr := tx.Rollback()
+		if err == nil && cerr != sql.ErrTxDone {
+			err = cerr
+		}
+	}()
+
+	err = p.store.execBuilder(tx, sq.
+		Update("IR_Playbook").
+		SetMap(map[string]interface{}{
+			"Title":                updated.Title,
+			"TeamID":               updated.TeamID,
+			"CreatePublicIncident": updated.CreatePublicIncident,
+			"DeleteAt":             updated.DeleteAt,
+			"ChecklistsJSON":       checklistsJSON,
+		}).
+		Where(sq.Eq{"ID": updated.ID}))
+
+	if err != nil {
+		return errors.Wrapf(err, "failed to update playbook with id '%s'", updated.ID)
+	}
+
+	if err = p.replacePlaybookMembers(tx, updated); err != nil {
+		return errors.Wrapf(err, "failed to replace playbook members for playbook with id '%s'", updated.ID)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return errors.Wrap(err, "could not commit transaction")
+	}
+
+	return nil
+}
+
+// Delete deletes a playbook.
+// TODO: is this what we want to do now? (Never delete, just set deleteAt?)
+func (p *playbookStore) Delete(id string) error {
+	pbook, err := p.Get(id)
+	if err != nil {
+		return err
+	}
+
+	pbook.DeleteAt = model.GetMillis()
+
+	return p.Update(pbook)
+}
+
+func checklistsToJSON(pbook playbook.Playbook) (json.RawMessage, error) {
+	for _, c := range pbook.Checklists {
+		if c.ID == "" {
+			c.ID = model.NewId()
+		}
+		for _, i := range c.Items {
+			if i.ID == "" {
+				i.ID = model.NewId()
+			}
+		}
+	}
+
+	checklistsJSON, err := json.Marshal(pbook.Checklists)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to marshal checklist json for playbook id: '%s'", pbook.ID)
+	}
+
+	return checklistsJSON, nil
+}
+
+// replacePlaybookMembers replaces (updates or inserts) the members of a playbook
+func (p *playbookStore) replacePlaybookMembers(e execer, pbook playbook.Playbook) error {
+	builder := sq.Replace("IR_PlaybookMember").
+		Columns("PlaybookID", "MemberID")
+
+	for _, m := range pbook.MemberIDs {
+		builder.Values(pbook.ID, m)
+	}
+
+	return p.store.execBuilder(e, builder)
+}
+
+func addMembersToPlaybooks(memberIDs playbookMembers, out []playbook.Playbook) {
+	pToM := make(map[string][]string)
+	for _, m := range memberIDs {
+		pToM[m.PlaybookID] = append(pToM[m.PlaybookID], m.MemberID)
+	}
+	for _, p := range out {
+		p.MemberIDs = pToM[p.ID]
+	}
+}

--- a/server/sqlstore/pluginapi_client.go
+++ b/server/sqlstore/pluginapi_client.go
@@ -6,15 +6,6 @@ import (
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
 )
 
-// KVAPI is the key value store interface for the pluginkv stores.
-// It is implemented by mattermost-plugin-api/Client.KV, or by the mock KVAPI.
-type KVAPI interface {
-	Set(key string, value interface{}, options ...pluginapi.KVSetOption) (bool, error)
-	Get(key string, out interface{}) error
-	SetAtomicWithRetries(key string, valueFunc func(oldValue []byte) (newValue interface{}, err error)) error
-	DeleteAll() error
-}
-
 // StoreAPI is the interface exposing the underlying database, provided by pluginapi
 // It is implemented by mattermost-plugin-api/Client.Store, or by the mock StoreAPI.
 type StoreAPI interface {
@@ -25,7 +16,6 @@ type StoreAPI interface {
 // PluginAPIClient is the struct combining the interfaces defined above, which is everything
 // from pluginapi that the store currently uses.
 type PluginAPIClient struct {
-	KV    KVAPI
 	Store StoreAPI
 }
 
@@ -33,7 +23,6 @@ type PluginAPIClient struct {
 // store will use to access pluginapi.Client.
 func NewClient(api *pluginapi.Client) PluginAPIClient {
 	return PluginAPIClient{
-		KV:    &api.KV,
 		Store: api.Store,
 	}
 }


### PR DESCRIPTION
#### Summary
- Based on #252 , so will need to rebase off that once it's merged (sorry @agarciamontoro)
- note for #252 : I think I was using transactions wrong, and needed to add the execer and queryer back to the sqlstore/store.go
- In order to move the sorting logic in `GetPlaybooksForTeam` completely into a SQL query, I'm adding two columns to the schema `Stages` and `Steps`. They won't be pulled out into the model, they're just there for sorting in SQL queries. I think this is pretty cool. This is why /not/ using an ORM was the best decision!
- Like #252, I'm eyeballing the SQL, so I'm sure I've made a few mistakes, sorry Alejandro
- Alejandro will take this over for the reviews and revisions, thanks!

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-27002
