### PR TITLE
MM-26611: use compass icons

### DIFF
--- a/webapp/src/components/assets/icons/dot_menu_icon.tsx
+++ b/webapp/src/components/assets/icons/dot_menu_icon.tsx
@@ -1,24 +1,16 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License for license information.
 
-import React, {FC} from 'react';
+import React from 'react';
 
-const DotMenuIcon: FC = () => {
-    return (
-        <svg
-            width='12'
-            height='4'
-            viewBox='0 0 12 4'
-            fill='none'
-            xmlns='http://www.w3.org/2000/svg'
-        >
-            <path
-                d='M9.006 2.00005C9.006 1.59205 9.15 1.24405 9.438 0.956048C9.738 0.656048 10.092 0.506048 10.5 0.506048C10.908 0.506048 11.256 0.656048 11.544 0.956048C11.844 1.24405 11.994 1.59205 11.994 2.00005C11.994 2.40805 11.844 2.76205 11.544 3.06205C11.256 3.35005 10.908 3.49405 10.5 3.49405C10.092 3.49405 9.738 3.35005 9.438 3.06205C9.15 2.76205 9.006 2.40805 9.006 2.00005ZM4.506 2.00005C4.506 1.59205 4.65 1.24405 4.938 0.956048C5.238 0.656048 5.592 0.506048 6 0.506048C6.408 0.506048 6.756 0.656048 7.044 0.956048C7.344 1.24405 7.494 1.59205 7.494 2.00005C7.494 2.40805 7.344 2.76205 7.044 3.06205C6.756 3.35005 6.408 3.49405 6 3.49405C5.592 3.49405 5.238 3.35005 4.938 3.06205C4.65 2.76205 4.506 2.40805 4.506 2.00005ZM0.00600019 2.00005C0.00600019 1.59205 0.15 1.24405 0.438 0.956048C0.738 0.656048 1.092 0.506048 1.5 0.506048C1.908 0.506048 2.256 0.656048 2.544 0.956048C2.844 1.24405 2.994 1.59205 2.994 2.00005C2.994 2.40805 2.844 2.76205 2.544 3.06205C2.256 3.35005 1.908 3.49405 1.5 3.49405C1.092 3.49405 0.738 3.35005 0.438 3.06205C0.15 2.76205 0.00600019 2.40805 0.00600019 2.00005Z'
-                fill='rgba(var(--center-channel-color-rgb), 0.56)'
-                fillOpacity='0.56'
-            />
-        </svg>
-    );
-};
+import styled from 'styled-components';
 
-export default DotMenuIcon;
+const DotMenuIcon = (props: React.PropsWithoutRef<JSX.IntrinsicElements['i']>): JSX.Element => (
+    <i className={`icon icon-dots-horizontal icon-16 ${props.className}`}/>
+);
+
+export default styled(DotMenuIcon)`
+    color: rgba(var(--center-channel-color-rgb), 0.56);
+    position: relative;
+    left: -8px;
+`;

--- a/webapp/src/components/assets/icons/file_icon.tsx
+++ b/webapp/src/components/assets/icons/file_icon.tsx
@@ -1,21 +1,14 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License for license information.
 
-import React, {FC} from 'react';
+import React from 'react';
 
-const FileIcon: FC = () => (
-    <svg
-        width='26'
-        height='35'
-        viewBox='0 0 26 35'
-        fill='none'
-        xmlns='http://www.w3.org/2000/svg'
-    >
-        <path
-            d='M24.7539 6.75781L19.2422 1.17969C18.6445 0.582031 17.7812 0.25 16.9844 0.25H3.4375C1.64453 0.25 0.25 1.71094 0.25 3.4375V31.0625C0.25 32.8555 1.64453 34.25 3.4375 34.25H22.5625C24.2891 34.25 25.75 32.8555 25.75 31.0625V9.01562C25.75 8.21875 25.3516 7.35547 24.7539 6.75781ZM23.293 8.28516C23.4258 8.41797 23.4922 8.61719 23.5586 8.75H17.25V2.44141C17.3828 2.50781 17.582 2.57422 17.7148 2.70703L23.293 8.28516ZM22.5625 32.125H3.4375C2.83984 32.125 2.375 31.6602 2.375 31.0625V3.4375C2.375 2.90625 2.83984 2.375 3.4375 2.375H15.125V9.28125C15.125 10.2109 15.7891 10.875 16.7188 10.875H23.625V31.0625C23.625 31.6602 23.0938 32.125 22.5625 32.125Z'
-            fill='var(--mention-highlight-link)'
-        />
-    </svg>
+import styled from 'styled-components';
+
+const FileIcon = (props: React.PropsWithoutRef<JSX.IntrinsicElements['i']>): JSX.Element => (
+    <i className={`icon icon-file-outline icon-32 ${props.className}`}/>
 );
 
-export default FileIcon;
+export default styled(FileIcon)`
+    color: var(--mention-highlight-link);
+`;


### PR DESCRIPTION
#### Summary
This adopts the dot menu and file compass icons from the mattermost webapp. Pending discussion at https://community-daily.mattermost.com/core/pl/z4skuuxooj8gpy7rcr85ze3wmh.

Before:
<img width="129" alt="image" src="https://user-images.githubusercontent.com/1023171/91510359-3ab5bb80-e8b3-11ea-80fa-31b96d9f2cc6.png">
<img width="236" alt="image" src="https://user-images.githubusercontent.com/1023171/91510368-41dcc980-e8b3-11ea-9da3-dcf3550d7c18.png">

After:
<img width="90" alt="image" src="https://user-images.githubusercontent.com/1023171/91510390-4dc88b80-e8b3-11ea-920b-c40bda354802.png">
<img width="239" alt="image" src="https://user-images.githubusercontent.com/1023171/91510423-65077900-e8b3-11ea-886d-93cfaa98b5a3.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26611