### PR TITLE
prompt for incident name and description

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -176,14 +176,23 @@ func (h *IncidentHandler) createIncidentFromDialog(w http.ResponseWriter, r *htt
 		return
 	}
 
-	name := request.Submission[incident.DialogFieldNameKey].(string)
-	playbookID := request.Submission[incident.DialogFieldPlaybookIDKey].(string)
+	var playbookID, name, description string
+	if rawPlaybookID, ok := request.Submission[incident.DialogFieldPlaybookIDKey].(string); ok {
+		playbookID = rawPlaybookID
+	}
+	if rawName, ok := request.Submission[incident.DialogFieldNameKey].(string); ok {
+		name = rawName
+	}
+	if rawDescription, ok := request.Submission[incident.DialogFieldDescriptionKey].(string); ok {
+		description = rawDescription
+	}
 
 	payloadIncident := incident.Incident{
 		Header: incident.Header{
 			CommanderUserID: request.UserId,
 			TeamID:          request.TeamId,
 			Name:            name,
+			Description:     description,
 		},
 		PostID:   state.PostID,
 		Playbook: &playbook.Playbook{ID: playbookID},
@@ -194,7 +203,7 @@ func (h *IncidentHandler) createIncidentFromDialog(w http.ResponseWriter, r *htt
 		var msg string
 
 		if errors.Is(err, incident.ErrChannelDisplayNameInvalid) {
-			msg = "The channel name is invalid or too long. Please use a valid name with fewer than 64 characters."
+			msg = "The incident name is invalid or too long. Please use a valid name with fewer than 64 characters."
 		} else if errors.Is(err, incident.ErrPermission) {
 			msg = err.Error()
 		}

--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -69,8 +69,8 @@ func TestIncidents(t *testing.T) {
 			UserId: "testUserID",
 			State:  "{}",
 			Submission: map[string]interface{}{
-				incident.DialogFieldNameKey:       "incidentName",
 				incident.DialogFieldPlaybookIDKey: "playbookid1",
+				incident.DialogFieldNameKey:       "incidentName",
 			},
 		}
 
@@ -80,6 +80,57 @@ func TestIncidents(t *testing.T) {
 				CommanderUserID: dialogRequest.UserId,
 				TeamID:          dialogRequest.TeamId,
 				Name:            "incidentName",
+			},
+			Playbook: &withid,
+		}
+		retI := i
+		retI.PrimaryChannelID = "channelID"
+		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
+		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
+		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		poster.EXPECT().PublishWebsocketEventToUser(gomock.Any(), gomock.Any(), gomock.Any())
+		poster.EXPECT().Ephemeral(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		incidentService.EXPECT().CreateIncident(&i, true).Return(&retI, nil)
+
+		testrecorder := httptest.NewRecorder()
+		testreq, err := http.NewRequest("POST", "/api/v1/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
+		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		require.NoError(t, err)
+		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
+
+		resp := testrecorder.Result()
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("create valid incident from dialog with description", func(t *testing.T) {
+		reset()
+
+		withid := playbook.Playbook{
+			ID:                   "playbookid1",
+			Title:                "My Playbook",
+			TeamID:               "testteamid",
+			CreatePublicIncident: true,
+		}
+
+		dialogRequest := model.SubmitDialogRequest{
+			TeamId: "testTeamID",
+			UserId: "testUserID",
+			State:  "{}",
+			Submission: map[string]interface{}{
+				incident.DialogFieldPlaybookIDKey:  "playbookid1",
+				incident.DialogFieldNameKey:        "incidentName",
+				incident.DialogFieldDescriptionKey: "description",
+			},
+		}
+
+		mockkvapi.EXPECT().Get(pluginkvstore.PlaybookKey+"playbookid1", gomock.Any()).Return(nil).SetArg(1, withid)
+		i := incident.Incident{
+			Header: incident.Header{
+				CommanderUserID: dialogRequest.UserId,
+				TeamID:          dialogRequest.TeamId,
+				Name:            "incidentName",
+				Description:     "description",
 			},
 			Playbook: &withid,
 		}
@@ -118,8 +169,8 @@ func TestIncidents(t *testing.T) {
 			UserId: "testUserID",
 			State:  "{}",
 			Submission: map[string]interface{}{
-				incident.DialogFieldNameKey:       "incidentName",
 				incident.DialogFieldPlaybookIDKey: "playbookid1",
+				incident.DialogFieldNameKey:       "incidentName",
 			},
 		}
 
@@ -176,8 +227,8 @@ func TestIncidents(t *testing.T) {
 			UserId: "testUserID",
 			State:  "{}",
 			Submission: map[string]interface{}{
-				incident.DialogFieldNameKey:       "incidentName",
 				incident.DialogFieldPlaybookIDKey: "playbookid1",
+				incident.DialogFieldNameKey:       "incidentName",
 			},
 		}
 
@@ -227,8 +278,8 @@ func TestIncidents(t *testing.T) {
 			UserId: "testUserID",
 			State:  "{}",
 			Submission: map[string]interface{}{
-				incident.DialogFieldNameKey:       "incidentName",
 				incident.DialogFieldPlaybookIDKey: "playbookid1",
+				incident.DialogFieldNameKey:       "incidentName",
 			},
 		}
 

--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -60,7 +60,7 @@ func TestIncidents(t *testing.T) {
 		withid := playbook.Playbook{
 			ID:                   "playbookid1",
 			Title:                "My Playbook",
-			TeamID:               "testteamid",
+			TeamID:               "testTeamID",
 			CreatePublicIncident: true,
 		}
 
@@ -86,15 +86,15 @@ func TestIncidents(t *testing.T) {
 		retI := i
 		retI.PrimaryChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
 		poster.EXPECT().PublishWebsocketEventToUser(gomock.Any(), gomock.Any(), gomock.Any())
 		poster.EXPECT().Ephemeral(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 		incidentService.EXPECT().CreateIncident(&i, true).Return(&retI, nil)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v1/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -109,7 +109,7 @@ func TestIncidents(t *testing.T) {
 		withid := playbook.Playbook{
 			ID:                   "playbookid1",
 			Title:                "My Playbook",
-			TeamID:               "testteamid",
+			TeamID:               "testTeamID",
 			CreatePublicIncident: true,
 		}
 
@@ -137,15 +137,15 @@ func TestIncidents(t *testing.T) {
 		retI := i
 		retI.PrimaryChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
 		poster.EXPECT().PublishWebsocketEventToUser(gomock.Any(), gomock.Any(), gomock.Any())
 		poster.EXPECT().Ephemeral(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 		incidentService.EXPECT().CreateIncident(&i, true).Return(&retI, nil)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v1/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -160,7 +160,7 @@ func TestIncidents(t *testing.T) {
 		withid := playbook.Playbook{
 			ID:                   "playbookid1",
 			Title:                "My Playbook",
-			TeamID:               "testteamid",
+			TeamID:               "testTeamID",
 			CreatePublicIncident: true,
 		}
 
@@ -186,12 +186,12 @@ func TestIncidents(t *testing.T) {
 		retI := i
 		retI.PrimaryChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(false)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(false)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v1/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -218,7 +218,7 @@ func TestIncidents(t *testing.T) {
 		withid := playbook.Playbook{
 			ID:                   "playbookid1",
 			Title:                "My Playbook",
-			TeamID:               "testteamid",
+			TeamID:               "testTeamID",
 			CreatePublicIncident: false,
 		}
 
@@ -244,12 +244,12 @@ func TestIncidents(t *testing.T) {
 		retI := i
 		retI.PrimaryChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_CREATE_PRIVATE_CHANNEL).Return(false)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PRIVATE_CHANNEL).Return(false)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v1/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -284,11 +284,11 @@ func TestIncidents(t *testing.T) {
 		}
 
 		mockkvapi.EXPECT().Get(pluginkvstore.PlaybookKey+"playbookid1", gomock.Any()).Return(nil).SetArg(1, playbook.Playbook{})
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v1/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -303,7 +303,7 @@ func TestIncidents(t *testing.T) {
 		withid := playbook.Playbook{
 			ID:                   "playbookid1",
 			Title:                "My Playbook",
-			TeamID:               "testteamid",
+			TeamID:               "testTeamID",
 			CreatePublicIncident: true,
 		}
 
@@ -322,8 +322,8 @@ func TestIncidents(t *testing.T) {
 		retI.ID = "incidentID"
 		retI.PrimaryChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
 		incidentService.EXPECT().CreateIncident(&testIncident, true).Return(&retI, nil)
 
 		incidentJSON, err := json.Marshal(testIncident)
@@ -331,7 +331,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v1/incidents", bytes.NewBuffer(incidentJSON))
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -360,8 +360,8 @@ func TestIncidents(t *testing.T) {
 		retI.ID = "incidentID"
 		retI.PrimaryChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
 		incidentService.EXPECT().CreateIncident(&testIncident, true).Return(&retI, nil)
 
 		incidentJSON, err := json.Marshal(testIncident)
@@ -369,7 +369,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v1/incidents", bytes.NewBuffer(incidentJSON))
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -394,15 +394,15 @@ func TestIncidents(t *testing.T) {
 		}
 
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
 
 		incidentJSON, err := json.Marshal(testIncident)
 		require.NoError(t, err)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v1/incidents", bytes.NewBuffer(incidentJSON))
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -422,14 +422,13 @@ func TestIncidents(t *testing.T) {
 		}
 
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
 
 		incidentJSON, err := json.Marshal(testIncident)
 		require.NoError(t, err)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v1/incidents", bytes.NewBuffer(incidentJSON))
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -450,14 +449,14 @@ func TestIncidents(t *testing.T) {
 		}
 
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
 
 		incidentJSON, err := json.Marshal(testIncident)
 		require.NoError(t, err)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v1/incidents", bytes.NewBuffer(incidentJSON))
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -490,7 +489,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/channel/"+testIncidentHeader.PrimaryChannelID, nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -506,7 +505,7 @@ func TestIncidents(t *testing.T) {
 
 	t.Run("get incident by channel id - not found", func(t *testing.T) {
 		reset()
-		userID := "testuserid"
+		userID := "testUserID"
 
 		testIncidentHeader := incident.Header{
 			ID:               "incidentID",
@@ -555,7 +554,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/channel/"+testIncidentHeader.PrimaryChannelID, nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -582,7 +581,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", testIncident.PrimaryChannelID).
 			Return(&model.Channel{Type: model.CHANNEL_PRIVATE}, nil)
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		pluginAPI.On("HasPermissionToChannel", "testuserid", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
+		pluginAPI.On("HasPermissionToChannel", "testUserID", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
 			Return(false)
 
 		logger.EXPECT().Warnf(gomock.Any(), gomock.Any())
@@ -593,7 +592,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID, nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -620,7 +619,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", testIncident.PrimaryChannelID).
 			Return(&model.Channel{Type: model.CHANNEL_PRIVATE}, nil)
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		pluginAPI.On("HasPermissionToChannel", "testuserid", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
+		pluginAPI.On("HasPermissionToChannel", "testUserID", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
 			Return(true)
 
 		logger.EXPECT().Warnf(gomock.Any(), gomock.Any())
@@ -631,7 +630,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID, nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -663,9 +662,9 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", testIncident.PrimaryChannelID).
 			Return(&model.Channel{Type: model.CHANNEL_OPEN, TeamId: testIncident.TeamID}, nil)
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		pluginAPI.On("HasPermissionToChannel", "testuserid", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
+		pluginAPI.On("HasPermissionToChannel", "testUserID", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
 			Return(false)
-		pluginAPI.On("HasPermissionToTeam", "testuserid", testIncident.TeamID, model.PERMISSION_LIST_TEAM_CHANNELS).
+		pluginAPI.On("HasPermissionToTeam", "testUserID", testIncident.TeamID, model.PERMISSION_LIST_TEAM_CHANNELS).
 			Return(false)
 
 		logger.EXPECT().Warnf(gomock.Any(), gomock.Any())
@@ -676,7 +675,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID, nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -703,9 +702,9 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", testIncident.PrimaryChannelID).
 			Return(&model.Channel{Type: model.CHANNEL_OPEN, TeamId: testIncident.TeamID}, nil)
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		pluginAPI.On("HasPermissionToChannel", "testuserid", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
+		pluginAPI.On("HasPermissionToChannel", "testUserID", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
 			Return(false)
-		pluginAPI.On("HasPermissionToTeam", "testuserid", testIncident.TeamID, model.PERMISSION_LIST_TEAM_CHANNELS).
+		pluginAPI.On("HasPermissionToTeam", "testUserID", testIncident.TeamID, model.PERMISSION_LIST_TEAM_CHANNELS).
 			Return(true)
 
 		logger.EXPECT().Warnf(gomock.Any(), gomock.Any())
@@ -716,7 +715,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID, nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -748,7 +747,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", testIncident.PrimaryChannelID).
 			Return(&model.Channel{Type: model.CHANNEL_OPEN, TeamId: testIncident.TeamID}, nil)
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		pluginAPI.On("HasPermissionToChannel", "testuserid", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
+		pluginAPI.On("HasPermissionToChannel", "testUserID", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
 			Return(true)
 
 		logger.EXPECT().Warnf(gomock.Any(), gomock.Any())
@@ -759,7 +758,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID, nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -791,7 +790,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", testIncident.PrimaryChannelID).
 			Return(&model.Channel{Type: model.CHANNEL_PRIVATE}, nil)
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		pluginAPI.On("HasPermissionToChannel", "testuserid", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
+		pluginAPI.On("HasPermissionToChannel", "testUserID", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
 			Return(false)
 
 		logger.EXPECT().Warnf(gomock.Any(), gomock.Any())
@@ -802,7 +801,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID+"/details", nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -838,7 +837,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", testIncident.PrimaryChannelID).
 			Return(&model.Channel{Type: model.CHANNEL_PRIVATE}, nil)
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		pluginAPI.On("HasPermissionToChannel", "testuserid", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
+		pluginAPI.On("HasPermissionToChannel", "testUserID", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
 			Return(true)
 
 		logger.EXPECT().Warnf(gomock.Any(), gomock.Any())
@@ -853,7 +852,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID+"/details", nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -885,9 +884,9 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", testIncident.PrimaryChannelID).
 			Return(&model.Channel{Type: model.CHANNEL_OPEN, TeamId: testIncident.TeamID}, nil)
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		pluginAPI.On("HasPermissionToChannel", "testuserid", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
+		pluginAPI.On("HasPermissionToChannel", "testUserID", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
 			Return(false)
-		pluginAPI.On("HasPermissionToTeam", "testuserid", testIncident.TeamID, model.PERMISSION_LIST_TEAM_CHANNELS).
+		pluginAPI.On("HasPermissionToTeam", "testUserID", testIncident.TeamID, model.PERMISSION_LIST_TEAM_CHANNELS).
 			Return(false)
 
 		logger.EXPECT().Warnf(gomock.Any(), gomock.Any())
@@ -898,7 +897,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID+"/details", nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -934,9 +933,9 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", testIncident.PrimaryChannelID).
 			Return(&model.Channel{Type: model.CHANNEL_OPEN, TeamId: testIncident.TeamID}, nil)
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		pluginAPI.On("HasPermissionToChannel", "testuserid", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
+		pluginAPI.On("HasPermissionToChannel", "testUserID", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
 			Return(false)
-		pluginAPI.On("HasPermissionToTeam", "testuserid", testIncident.TeamID, model.PERMISSION_LIST_TEAM_CHANNELS).
+		pluginAPI.On("HasPermissionToTeam", "testUserID", testIncident.TeamID, model.PERMISSION_LIST_TEAM_CHANNELS).
 			Return(true)
 
 		logger.EXPECT().Warnf(gomock.Any(), gomock.Any())
@@ -951,7 +950,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID+"/details", nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -991,7 +990,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", testIncident.PrimaryChannelID).
 			Return(&model.Channel{Type: model.CHANNEL_OPEN, TeamId: testIncident.TeamID}, nil)
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		pluginAPI.On("HasPermissionToChannel", "testuserid", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
+		pluginAPI.On("HasPermissionToChannel", "testUserID", testIncident.PrimaryChannelID, model.PERMISSION_READ_CHANNEL).
 			Return(true)
 
 		logger.EXPECT().Warnf(gomock.Any(), gomock.Any())
@@ -1006,7 +1005,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID+"/details", nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -1045,7 +1044,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents", nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -1080,7 +1079,7 @@ func TestIncidents(t *testing.T) {
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents", nil)
-		testreq.Header.Add("Mattermost-User-ID", "testuserid")
+		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
@@ -1152,7 +1151,7 @@ func TestChangeActiveStage(t *testing.T) {
 		return &playbook.Playbook{
 			ID:                   "playbookid",
 			Title:                "My Playbook",
-			TeamID:               "testteamid",
+			TeamID:               "testTeamID",
 			CreatePublicIncident: true,
 			Checklists:           checklists,
 		}
@@ -1263,7 +1262,7 @@ func TestChangeActiveStage(t *testing.T) {
 			expectedIncident := data.getExpectedIncident(data.oldIncident)
 			if data.updateOptions.ActiveStage != nil {
 				incidentService.EXPECT().
-					ChangeActiveStage(data.oldIncident.ID, "testuserid", *data.updateOptions.ActiveStage).
+					ChangeActiveStage(data.oldIncident.ID, "testUserID", *data.updateOptions.ActiveStage).
 					Return(expectedIncident, data.changeActiveStageErr).
 					Times(1)
 			}
@@ -1273,7 +1272,7 @@ func TestChangeActiveStage(t *testing.T) {
 			updatesJSON, err := json.Marshal(data.updateOptions)
 			require.NoError(t, err)
 			testreq, err := http.NewRequest("PATCH", "/api/v1/incidents/"+data.oldIncident.ID, bytes.NewBuffer(updatesJSON))
-			testreq.Header.Add("Mattermost-User-ID", "testuserid")
+			testreq.Header.Add("Mattermost-User-ID", "testUserID")
 			require.NoError(t, err)
 			handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -18,6 +18,7 @@ type Incident struct {
 type Header struct {
 	ID               string `json:"id"`
 	Name             string `json:"name"`
+	Description      string `json:"description"`
 	IsActive         bool   `json:"is_active"`
 	CommanderUserID  string `json:"commander_user_id"`
 	TeamID           string `json:"team_id"`

--- a/tests-e2e/cypress/integration/frontstage/incident_creation_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_creation_spec.js
@@ -204,4 +204,16 @@ describe('incidents can be started', () => {
             cy.verifyIncidentCreated(incidentName);
         });
     });
+
+    it('with a description', () => {
+        // # Visit a public channel: off-topic
+        cy.visit('/ad-1/channels/off-topic');
+
+        // * Verify that incident can be started from incident RHS
+        const now = Date.now();
+        const incidentName = 'With Description - ' + now;
+        const incidentDescription = 'Description - ' + now;
+        cy.startIncidentWithSlashCommand(playbookName, incidentName, incidentDescription);
+        cy.verifyIncidentCreated(incidentName, incidentDescription);
+    });
 });

--- a/tests-e2e/cypress/integration/frontstage/incident_dialog_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_dialog_spec.js
@@ -56,6 +56,7 @@ describe('incident creation dialog', () => {
         cy.findByTestId('autoCompleteSelector').contains('Playbook');
         cy.findByTestId('autoCompleteSelector').contains('This field is required.');
         cy.findByTestId('incidentName').contains('This field is required.');
+        cy.findByTestId('incidentDescription').contains('This field is required.').should('not.exist');
     });
 
     it('shows create playbook link', () => {
@@ -76,8 +77,11 @@ describe('incident creation dialog', () => {
             // * Verify playbook dropdown prompt
             cy.findByText('Playbook').should('be.visible');
 
-            // * Verify channel name prompt
-            cy.findByText('Channel Name').should('be.visible');
+            // * Verify incident name prompt
+            cy.findByText('Incident Name').should('be.visible');
+
+            // * Verify incident description prompt
+            cy.findByText('Incident Description').should('be.visible');
         });
     });
 

--- a/tests-e2e/cypress/support/plugin_api_commands.js
+++ b/tests-e2e/cypress/support/plugin_api_commands.js
@@ -52,12 +52,19 @@ Cypress.Commands.add('apiDeleteIncident', (incidentId) => {
 });
 
 // Verify incident is created
-Cypress.Commands.add('verifyIncidentCreated', (incidentName) => {
+Cypress.Commands.add('verifyIncidentCreated', (incidentName, incidentDescription) => {
     cy.apiGetAllIncidents().then((response) => {
         const allIncidents = JSON.parse(response.body);
         const incident = allIncidents.items.find((inc) => inc.name === incidentName);
         assert.isDefined(incident);
         assert.isTrue(incident.is_active);
+        assert.equal(incident.name, incidentName);
+
+        // Only check the description if provided. The server may supply a default depending
+        // on how the incident was started.
+        if (incidentDescription) {
+            assert.equal(incident.description, incidentDescription);
+        }
     });
 });
 

--- a/tests-e2e/cypress/support/plugin_ui_commands.js
+++ b/tests-e2e/cypress/support/plugin_ui_commands.js
@@ -6,13 +6,18 @@ import * as TIMEOUTS from '../fixtures/timeouts';
 const incidentStartCommand = '/incident start';
 
 // function startIncident(incidentName) {
-Cypress.Commands.add('startIncident', (playbookName, incidentName) => {
+Cypress.Commands.add('startIncident', (playbookName, incidentName, incidentDescription) => {
     cy.get('#interactiveDialogModal').should('be.visible').within(() => {
         // # Select playbook
         cy.selectPlaybookFromDropdown(playbookName);
 
-        // # Type channel name
+        // # Type incident name
         cy.findByTestId('incidentNameinput').type(incidentName, {force: true});
+
+        // # Type description, if any
+        if (incidentDescription) {
+            cy.findByTestId('incidentDescriptioninput').type(incidentDescription, {force: true});
+        }
 
         // # Submit
         cy.get('#interactiveDialogSubmit').click();
@@ -30,10 +35,10 @@ Cypress.Commands.add('openIncidentDialogFromSlashCommand', () => {
 
 // Starts incident with the `/incident start` slash command
 // function startIncidentWithSlashCommand(incidentName) {
-Cypress.Commands.add('startIncidentWithSlashCommand', (playbookName, incidentName) => {
+Cypress.Commands.add('startIncidentWithSlashCommand', (playbookName, incidentName, incidentDescription) => {
     cy.openIncidentDialogFromSlashCommand();
 
-    cy.startIncident(playbookName, incidentName);
+    cy.startIncident(playbookName, incidentName, incidentDescription);
 });
 
 // Starts incident from the incident RHS


### PR DESCRIPTION
#### Summary
When starting an incident, prompt for an incident name (vs. the `channel name` currently provided), and then add a prompt for an optional description. The description ends up as the channel header.

When starting an incident from a post, this description will be pre-filled with the markdown we currently use to record a link to the post, but can be modified freely. We only show `The channel was created by the Incident Response plugin.` in the channel header if no description is provided.

<img width="610" alt="image" src="https://user-images.githubusercontent.com/1023171/92122005-53e9cb00-edd1-11ea-8fa5-dd38e732ad43.png">

<img width="616" alt="image" src="https://user-images.githubusercontent.com/1023171/92122076-66640480-edd1-11ea-80ab-7165eff48c66.png">

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-28311