### PR TITLE
Clarification to license section in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plugin allows you to coordinate and manage incidents within Mattermost.
 
 ## License
 
-This repository is licensed under the [Mattermost Source Available License](LICENSE) and requires a valid Enterprise E20 license. See [Mattermost Source Available License](https://docs.mattermost.com/overview/faq.html#mattermost-source-available-license) to learn more.
+This repository is licensed under the [Mattermost Source Available License](LICENSE) and requires a valid Enterprise E20 license. See [frequently asked questions](https://docs.mattermost.com/overview/faq.html#mattermost-source-available-license) to learn more.
 
 ## Community Contributions
 


### PR DESCRIPTION
We are hyperlinking "Mattermost Source Available License" twice, but each links to a different page.

Propose updating the second reference to "frequently asked questions", which links to the FAQ section in our docs.

@lieut-data @justinegeffen for reviewers (no permissions to add you as reviewers).