### PR TITLE
MM-27983: use defaultChecked when no onChange

### DIFF
--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -413,14 +413,18 @@ interface ChecklistItemButtonProps {
 
 const ChecklistItemButton: FC<ChecklistItemButtonProps> = (props: ChecklistItemButtonProps) => {
     const isChecked = props.item.state === ChecklistItemState.Closed;
-    const nextState = isChecked ? ChecklistItemState.Open : ChecklistItemState.Closed;
+
     return (
         <input
             className='checkbox'
             type='checkbox'
-            defaultChecked={isChecked}
-            onClick={() => {
-                props.onChange(nextState);
+            checked={isChecked}
+            onChange={() => {
+                if (isChecked) {
+                    props.onChange(ChecklistItemState.Open);
+                } else {
+                    props.onChange(ChecklistItemState.Closed);
+                }
             }}
         />);
 };

--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -418,7 +418,7 @@ const ChecklistItemButton: FC<ChecklistItemButtonProps> = (props: ChecklistItemB
         <input
             className='checkbox'
             type='checkbox'
-            checked={isChecked}
+            defaultChecked={isChecked}
             onClick={() => {
                 props.onChange(nextState);
             }}


### PR DESCRIPTION
#### Summary
React throws a warning when using `checked` without `onChange`. Since we use `onClick` with this component, use `defaultChecked` instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27983