### PR TITLE
Playbook edit polish

### DIFF
--- a/webapp/src/components/backstage/editable_text.tsx
+++ b/webapp/src/components/backstage/editable_text.tsx
@@ -62,6 +62,9 @@ const EditableText: FC<EditableTextProps> = (props: EditableTextProps) => {
     };
 
     const enterEditMode = () => {
+        // When editing, copy the props value at the instant editing starts.
+        setText(props.text);
+
         // Start the input size at least as wide as the span, itself with a max width.
         setInputWidth(textElement.current?.offsetWidth || 0);
         setEditMode(true);
@@ -93,17 +96,18 @@ const EditableText: FC<EditableTextProps> = (props: EditableTextProps) => {
             </Container>
         );
     }
+
     return (
         <Container
             id={props.id}
             onClick={enterEditMode}
         >
-            {text && text.trim().length > 0 &&
+            {props.text && props.text.trim().length > 0 &&
                 <Text ref={textElement}>
-                    {text}
+                    {props.text}
                 </Text>
             }
-            {(!text || text.length === 0) && props.placeholder && props.placeholder.length > 0 &&
+            {(!props.text || props.text.length === 0) && props.placeholder && props.placeholder.length > 0 &&
                 <Text>
                     {props.placeholder}
                 </Text>

--- a/webapp/src/components/backstage/editable_text.tsx
+++ b/webapp/src/components/backstage/editable_text.tsx
@@ -46,6 +46,14 @@ const Text = styled.span`
     white-space: nowrap;
 `;
 
+const Placeholder = styled.span`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 450px;
+    white-space: nowrap;
+    font-style: italic;
+`;
+
 const ClickableI = styled.i`
     cursor: pointer;
 `;
@@ -108,9 +116,9 @@ const EditableText: FC<EditableTextProps> = (props: EditableTextProps) => {
                 </Text>
             }
             {(!props.text || props.text.length === 0) && props.placeholder && props.placeholder.length > 0 &&
-                <Text>
+                <Placeholder>
                     {props.placeholder}
-                </Text>
+                </Placeholder>
             }
             <ClickableI
                 className='editable-trigger icon-pencil-outline'

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -186,6 +186,20 @@ const FetchingStateType = {
     notFound: 'notfound',
 };
 
+// setPlaybookDefaults fills in a playbook with defaults for any fields left empty.
+const setPlaybookDefaults = (playbook: Playbook) => ({
+    ...playbook,
+    title: playbook.title.trim() || 'Untitled Playbook',
+    checklists: playbook.checklists.map((checklist) => ({
+        ...checklist,
+        title: checklist.title || 'Untitled Stage',
+        items: checklist.items.map((item) => ({
+            ...item,
+            title: item.title || 'Untitled Step',
+        })),
+    })),
+});
+
 const PlaybookEdit: FC<Props> = (props: Props) => {
     const dispatch = useDispatch();
 
@@ -244,18 +258,7 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
     }, [urlParams.playbookId, props.isNew]);
 
     const onSave = async () => {
-        await savePlaybook({
-            ...playbook,
-            title: playbook.title.trim() || 'Untitled Playbook',
-            checklists: playbook.checklists.map((checklist) => ({
-                ...checklist,
-                title: checklist.title || 'Untitled Stage',
-                items: checklist.items.map((item) => ({
-                    ...item,
-                    title: item.title || 'Untitled Step',
-                })),
-            })),
-        });
+        await savePlaybook(setPlaybookDefaults(playbook));
 
         props.onClose();
     };

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -269,6 +269,11 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
     };
 
     const handleTitleChange = (title: string) => {
+        if (title.trim().length === 0) {
+            // Keep the original title from the props.
+            return;
+        }
+
         setPlaybook({
             ...playbook,
             title,

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -6,7 +6,7 @@ import {Redirect, useParams, useLocation} from 'react-router-dom';
 import {useSelector, useDispatch} from 'react-redux';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {searchProfiles} from 'mattermost-redux/actions/users';
+import {getProfilesInTeam, searchProfiles} from 'mattermost-redux/actions/users';
 
 import {Team} from 'mattermost-redux/types/teams';
 
@@ -325,6 +325,10 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
         return dispatch(searchProfiles(term, {team_id: props.currentTeam.id}));
     };
 
+    const getUsers = () => {
+        return dispatch(getProfilesInTeam(props.currentTeam.id, 0));
+    };
+
     if (!props.isNew) {
         switch (fetchingState) {
         case FetchingStateType.notFound:
@@ -436,6 +440,7 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
                                 onAddUser={handleUsersInput}
                                 onRemoveUser={handleRemoveUser}
                                 searchProfiles={searchUsers}
+                                getProfiles={getUsers}
                                 playbook={playbook}
                             />
                         </SidebarBlock>

--- a/webapp/src/components/backstage/profile_autocomplete.tsx
+++ b/webapp/src/components/backstage/profile_autocomplete.tsx
@@ -35,6 +35,7 @@ const StyledAsyncSelect = styled(AsyncSelect)`
         -moz-transition: all 0.15s ease;
         -o-transition: all 0.15s ease;
         transition: all 0.15s ease;
+        transition-delay: 0s;
         background-color: transparent;
         border-radius: 4px;
         border: none;

--- a/webapp/src/components/backstage/profile_autocomplete.tsx
+++ b/webapp/src/components/backstage/profile_autocomplete.tsx
@@ -71,7 +71,8 @@ const StyledAsyncSelect = styled(AsyncSelect)`
 interface Props {
     userIds: string[];
     onAddUser: (userid: string) => void;
-    searchProfiles: (term: string) => ActionFunc
+    searchProfiles: (term: string) => ActionFunc;
+    getProfiles: () => ActionFunc;
 }
 
 const ProfileAutocomplete: FC<Props> = (props: Props) => {
@@ -92,8 +93,15 @@ const ProfileAutocomplete: FC<Props> = (props: Props) => {
     };
 
     const debouncedSearchProfiles = debounce((term: string, callback: (options: OptionsType<UserProfile>) => void) => {
+        let profiles;
+        if (term.trim().length === 0) {
+            profiles = props.getProfiles();
+        } else {
+            profiles = props.searchProfiles(term);
+        }
+
         //@ts-ignore
-        props.searchProfiles(term).then(({data}) => {
+        profiles.then(({data}) => {
             const profilesWithoutAlreadyAdded = data.filter((profile: UserProfile) => !props.userIds.includes(profile.id));
             callback(profilesWithoutAlreadyAdded);
         }).catch(() => {
@@ -118,13 +126,13 @@ const ProfileAutocomplete: FC<Props> = (props: Props) => {
             isMulti={false}
             controlShouldRenderValue={false}
             cacheOptions={false}
-            defaultOptions={false}
+            defaultOptions={true}
             loadOptions={usersLoader}
             onChange={onChange}
             getOptionValue={getOptionValue}
             formatOptionLabel={formatOptionLabel}
             defaultMenuIsOpen={false}
-            openMenuOnClick={false}
+            openMenuOnClick={true}
             isClearable={false}
             value={null}
             placeholder={'Add People'}

--- a/webapp/src/components/backstage/share_playbook.tsx
+++ b/webapp/src/components/backstage/share_playbook.tsx
@@ -12,6 +12,7 @@ export interface SharePlaybookProps {
     onAddUser: (userid: string) => void;
     onRemoveUser: (userid: string) => void;
     searchProfiles: (term: string) => ActionFunc;
+    getProfiles: () => ActionFunc;
     playbook: Playbook;
 }
 
@@ -50,6 +51,7 @@ const SharePlaybook: FC<SharePlaybookProps> = (props: SharePlaybookProps) => {
                 onAddUser={props.onAddUser}
                 userIds={props.playbook.member_ids}
                 searchProfiles={props.searchProfiles}
+                getProfiles={props.getProfiles}
             />
             <UserList>
                 {props.playbook.member_ids.map((userId) => (

--- a/webapp/src/components/backstage/stage_edit.tsx
+++ b/webapp/src/components/backstage/stage_edit.tsx
@@ -26,6 +26,7 @@ const DragPlaceholderText = styled.div`
     margin: 5px 50px;
     text-align: center;
     color: rgb(var(--button-bg-rgb));
+    cursor: pointer;
 `;
 
 interface Props {

--- a/webapp/src/components/backstage/stage_edit.tsx
+++ b/webapp/src/components/backstage/stage_edit.tsx
@@ -38,6 +38,11 @@ interface Props {
 export const StageEditor = (props: Props): React.ReactElement => {
     const onTitleChange = (newTitle: string) => {
         const trimmedTitle = newTitle.trim();
+        if (trimmedTitle.length === 0) {
+            // Keep the original title from the props.
+            return;
+        }
+
         const newChecklist = {
             ...props.checklist,
             title: trimmedTitle,

--- a/webapp/src/components/backstage/stages_and_steps_edit.tsx
+++ b/webapp/src/components/backstage/stages_and_steps_edit.tsx
@@ -196,7 +196,7 @@ export const StagesAndStepsEdit = (props: Props): React.ReactElement => {
             <ConfirmModal
                 show={confirmRemoveChecklistNum >= 0}
                 title={'Remove Stage'}
-                message={'Are you sere you want to remove the stage? All steps will be removed.'}
+                message={'Are you sure you want to remove the stage? All steps will be removed.'}
                 confirmButtonText={'Remove Stage'}
                 onConfirm={() => {
                     onRemoveChecklist(confirmRemoveChecklistNum);

--- a/webapp/src/components/backstage/step_edit.tsx
+++ b/webapp/src/components/backstage/step_edit.tsx
@@ -142,7 +142,15 @@ interface StepTitleProps {
 const StepTitle: FC<StepTitleProps> = (props: StepTitleProps) => {
     const [title, setTitle] = useState(props.title);
 
-    const save = () => props.setTitle(title);
+    const save = () => {
+        if (title.trim().length === 0) {
+            // Keep the original title from the props.
+            setTitle(props.title);
+            return;
+        }
+
+        props.setTitle(title);
+    };
 
     return (
         <StepInput

--- a/webapp/src/components/backstage/step_edit.tsx
+++ b/webapp/src/components/backstage/step_edit.tsx
@@ -176,7 +176,7 @@ interface StepDescriptionProps {
 
 const StepDescription: FC<StepDescriptionProps> = (props: StepDescriptionProps) => {
     const [description, setDescription] = useState(props.description);
-    const [hasValue, setHasValue] = useState(props.description.length > 0);
+    const [descriptionOpen, setDescriptionOpen] = useState(props.description.length > 0);
     const [hover, setHover] = useState(false);
     const [focus, setFocus] = useState(false);
     const ref = useRef(null);
@@ -196,7 +196,7 @@ const StepDescription: FC<StepDescriptionProps> = (props: StepDescriptionProps) 
     let descriptionBox = (
         <AddDescription
             onClick={() => {
-                setHasValue(true);
+                setDescriptionOpen(true);
                 setFocus(true);
             }}
         >
@@ -204,7 +204,7 @@ const StepDescription: FC<StepDescriptionProps> = (props: StepDescriptionProps) 
             {'Add Optional Description'}
         </AddDescription>
     );
-    if (hasValue) {
+    if (descriptionOpen) {
         descriptionBox = (
             <>
                 <Description
@@ -220,7 +220,7 @@ const StepDescription: FC<StepDescriptionProps> = (props: StepDescriptionProps) 
                     <i
                         className='icon-trash-can-outline icon-12 icon--no-spacing mr-1'
                         onClick={() => {
-                            setHasValue(false);
+                            setDescriptionOpen(false);
                             setDescription('');
                             props.setDescription('');
                         }}
@@ -248,7 +248,7 @@ interface StepCommandProps {
 
 const StepCommand: FC<StepCommandProps> = (props: StepCommandProps) => {
     const [command, setCommand] = useState(props.command);
-    const [hasValue, setHasValue] = useState(props.command.length > 0);
+    const [commandOpen, setCommandOpen] = useState(props.command.length > 0);
     const [focus, setFocus] = useState(false);
     const [hover, setHover] = useState(false);
     const ref = useRef(null);
@@ -273,7 +273,7 @@ const StepCommand: FC<StepCommandProps> = (props: StepCommandProps) => {
     let slashCommandBox = (
         <TertiaryButton
             onClick={() => {
-                setHasValue(true);
+                setCommandOpen(true);
                 setCommand('/');
                 setFocus(true);
             }}
@@ -283,7 +283,7 @@ const StepCommand: FC<StepCommandProps> = (props: StepCommandProps) => {
         </TertiaryButton>
     );
 
-    if (hasValue) {
+    if (commandOpen) {
         slashCommandBox = (<>
             <OverrideWebappStyle/>
             <AutocompleteWrapper>
@@ -319,7 +319,7 @@ const StepCommand: FC<StepCommandProps> = (props: StepCommandProps) => {
                     <i
                         className='icon-trash-can-outline icon-12 icon--no-spacing mr-1'
                         onClick={() => {
-                            setHasValue(false);
+                            setCommandOpen(false);
                             setCommand('');
                             props.setCommand('');
                         }}


### PR DESCRIPTION
#### Summary
A grabbag of changes from a recent design review and some opinionated changes along the way.

* When sharing a playbook, show profiles on first click even before searching.
* Show "Add Slash Command" button until a slash command is added, and then automatically show slash command auto-complete on focus. (Requires parallel webapp changes.)
* Tweak step description adding and removing.
* Style placeholder text with italics:

Finally, allow `Save` at all times, and not just when there are changes. This eliminates a number of weird edge cases where the `Save` button sometimes shows up enabled and sometimes not, and always provides a safe "exit path" vs. having to figure out how to get out of editing without losing potential changes. As part of this, allow empty stage and step names, and just replace with default text for consistency in saving.

### Ticket
Fixes: https://mattermost.atlassian.net/browse/MM-28009