### PR TITLE
MM-28332: Add a fallback for when unaccent is not available (now ready to merge)

### DIFF
--- a/server/sqlstore/incident.go
+++ b/server/sqlstore/incident.go
@@ -95,12 +95,9 @@ func (s *incidentStore) GetIncidents(requesterInfo incident.RequesterInfo, optio
 		// Postgres performs a case-sensitive search, so we need to lowercase
 		// both the column contents and the search string
 		if s.store.db.DriverName() == model.DATABASE_DRIVER_POSTGRES {
-			var unaccentExists bool
-			err := s.store.getBuilder(s.store.db, &unaccentExists,
-				sq.Expr("SELECT EXISTS(SELECT * FROM pg_proc WHERE proname = 'unaccent')"))
+			unaccentExists, err := s.store.isUnaccentAvailable()
 			if err != nil {
 				s.store.log.Errorf("failed to check if the unaccent function exists: %w", err)
-				unaccentExists = false
 			}
 
 			if unaccentExists {

--- a/server/sqlstore/incident.go
+++ b/server/sqlstore/incident.go
@@ -95,8 +95,21 @@ func (s *incidentStore) GetIncidents(requesterInfo incident.RequesterInfo, optio
 		// Postgres performs a case-sensitive search, so we need to lowercase
 		// both the column contents and the search string
 		if s.store.db.DriverName() == model.DATABASE_DRIVER_POSTGRES {
-			column = "LOWER(UNACCENT(Name))"
-			searchString = normalize(options.SearchTerm)
+			var unaccentExists bool
+			err := s.store.getBuilder(s.store.db, &unaccentExists,
+				sq.Expr("SELECT EXISTS(SELECT * FROM pg_proc WHERE proname = 'unaccent')"))
+			if err != nil {
+				s.store.log.Errorf("failed to check if the unaccent function exists: %w", err)
+				unaccentExists = false
+			}
+
+			if unaccentExists {
+				column = "LOWER(UNACCENT(Name))"
+				searchString = normalize(options.SearchTerm)
+			} else {
+				column = "LOWER(Name)"
+				searchString = strings.ToLower(options.SearchTerm)
+			}
 		}
 
 		queryForResults = queryForResults.Where(sq.Like{column: fmt.Sprint("%", searchString, "%")})

--- a/server/sqlstore/migrate.go
+++ b/server/sqlstore/migrate.go
@@ -29,7 +29,7 @@ func (sqlStore *SQLStore) migrate(pluginAPI PluginAPIClient, migration Migration
 	}
 	defer sqlStore.finalizeTransaction(tx)
 
-	if err := migration.migrationFunc(tx); err != nil {
+	if err := migration.migrationFunc(tx, sqlStore.log); err != nil {
 		return errors.Wrapf(err, "error executing migration from version %s to version %s", migration.fromVersion.String(), migration.toVersion.String())
 	}
 

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/blang/semver"
+	"github.com/mattermost/mattermost-plugin-incident-response/server/bot"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/pkg/errors"
 )
@@ -11,14 +12,14 @@ import (
 type Migration struct {
 	fromVersion   semver.Version
 	toVersion     semver.Version
-	migrationFunc func(execer) error
+	migrationFunc func(execer, bot.Logger) error
 }
 
 var migrations = []Migration{
 	{
 		fromVersion: semver.MustParse("0.0.0"),
 		toVersion:   semver.MustParse("0.1.0"),
-		migrationFunc: func(e execer) error {
+		migrationFunc: func(e execer, logger bot.Logger) error {
 			if _, err := e.Exec(`
 				CREATE TABLE IF NOT EXISTS IR_System (
 					SKey VARCHAR(64) PRIMARY KEY,
@@ -88,7 +89,7 @@ var migrations = []Migration{
 				if _, err := e.Exec(`
 					CREATE EXTENSION IF NOT EXISTS unaccent;
 				`); err != nil {
-					return errors.Wrapf(err, "failed creating extension unaccent")
+					logger.Errorf("Failed creating the unaccent extension, the search will be accent-sensitive. Error: %v", err)
 				}
 
 				if _, err := e.Exec(`
@@ -185,7 +186,7 @@ var migrations = []Migration{
 	{
 		fromVersion: semver.MustParse("0.1.0"),
 		toVersion:   semver.MustParse("0.2.0"),
-		migrationFunc: func(e execer) error {
+		migrationFunc: func(e execer, logger bot.Logger) error {
 			// migration to 0.2.0 is used to trigger the data migration from the kvstore.
 			return nil
 		},

--- a/server/sqlstore/store.go
+++ b/server/sqlstore/store.go
@@ -11,9 +11,10 @@ import (
 )
 
 type SQLStore struct {
-	log     bot.Logger
-	db      *sqlx.DB
-	builder sq.StatementBuilderType
+	log                 bot.Logger
+	db                  *sqlx.DB
+	builder             sq.StatementBuilderType
+	cachedUnaccentCheck *bool
 }
 
 // New constructs a new instance of SQLStore.
@@ -39,6 +40,7 @@ func New(pluginAPI PluginAPIClient, log bot.Logger) (*SQLStore, error) {
 		log,
 		db,
 		builder,
+		nil,
 	}, nil
 }
 

--- a/server/sqlstore/store_test.go
+++ b/server/sqlstore/store_test.go
@@ -1,0 +1,63 @@
+package sqlstore
+
+import (
+	"testing"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsUnaccentAvailable(t *testing.T) {
+	t.Run("Returns false in MySQL", func(t *testing.T) {
+		db := setupTestDB(t, model.DATABASE_DRIVER_MYSQL)
+		_, _, sqlStore := setupSQLStore(t, db)
+
+		unaccentExists, err := sqlStore.isUnaccentAvailable()
+		require.NoError(t, err)
+		require.False(t, unaccentExists)
+	})
+
+	t.Run("Returns true if it exists", func(t *testing.T) {
+		db := setupTestDB(t, model.DATABASE_DRIVER_POSTGRES)
+		_, _, sqlStore := setupSQLStore(t, db)
+
+		var rawUnaccentExists bool
+		err := sqlStore.getBuilder(sqlStore.db, &rawUnaccentExists,
+			sq.Expr("SELECT EXISTS(SELECT * FROM pg_proc WHERE proname = 'unaccent')"))
+		require.NoError(t, err)
+
+		require.True(t, rawUnaccentExists)
+
+		unaccentExists, err := sqlStore.isUnaccentAvailable()
+		require.NoError(t, err)
+		require.True(t, unaccentExists)
+	})
+
+	t.Run("Returns false if it does not exist", func(t *testing.T) {
+		db := setupTestDB(t, model.DATABASE_DRIVER_POSTGRES)
+		_, _, sqlStore := setupSQLStore(t, db)
+
+		_, err := sqlStore.execBuilder(sqlStore.db, sq.Expr("DROP EXTENSION IF EXISTS unaccent"))
+		require.NoError(t, err)
+
+		unaccentExists, err := sqlStore.isUnaccentAvailable()
+		require.NoError(t, err)
+		require.False(t, unaccentExists)
+	})
+
+	t.Run("Returns cached value if available", func(t *testing.T) {
+		db := setupTestDB(t, model.DATABASE_DRIVER_POSTGRES)
+		_, _, sqlStore := setupSQLStore(t, db)
+
+		sqlStore.cachedUnaccentCheck = bToP(true)
+		unaccentExists, err := sqlStore.isUnaccentAvailable()
+		require.NoError(t, err)
+		require.True(t, unaccentExists)
+
+		sqlStore.cachedUnaccentCheck = bToP(false)
+		unaccentExists, err = sqlStore.isUnaccentAvailable()
+		require.NoError(t, err)
+		require.False(t, unaccentExists)
+	})
+}

--- a/server/sqlstore/support_for_test.go
+++ b/server/sqlstore/support_for_test.go
@@ -70,6 +70,7 @@ func setupSQLStore(t *testing.T, db *sqlx.DB) (PluginAPIClient, bot.Logger, *SQL
 		logger,
 		db,
 		builder,
+		nil,
 	}
 
 	kvAPI.EXPECT().

--- a/server/sqlstore/system.go
+++ b/server/sqlstore/system.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/pkg/errors"
 )
 
@@ -51,4 +52,33 @@ func (sqlStore *SQLStore) setSystemValue(e execer, key, value string) error {
 	}
 
 	return nil
+}
+
+func (sqlStore *SQLStore) isUnaccentAvailable() (bool, error) {
+	if sqlStore.cachedUnaccentCheck != nil {
+		return *sqlStore.cachedUnaccentCheck, nil
+	}
+
+	if sqlStore.db.DriverName() != model.DATABASE_DRIVER_POSTGRES {
+		sqlStore.cachedUnaccentCheck = bToP(false)
+
+		return false, nil
+	}
+
+	var unaccentExists bool
+	err := sqlStore.getBuilder(sqlStore.db, &unaccentExists,
+		sq.Expr("SELECT EXISTS(SELECT * FROM pg_proc WHERE proname = 'unaccent')"))
+
+	if err != nil {
+		return false, err
+	}
+
+	sqlStore.cachedUnaccentCheck = &unaccentExists
+
+	return unaccentExists, err
+}
+
+// bToP stands for boolean To Pointer
+func bToP(b bool) *bool {
+	return &b
 }


### PR DESCRIPTION
#### Summary

A rebased copy of #280. The original summary:

- I've changed the migration so we don't finish it when we are unable to create the extension, but only log the error. Also, in case the extension fails to be created, I've added a fallback so we don't use it (I considered implementing a noop SQL function so we don't need to check whether the real function exists, but we would have the same problem: does the user has permissions to add a function?)
- I've smoke-tested that the general Mattermost search is not affected by this change. Also, I'm 99% sure it won't affect anything because all the extension does is adding a dictionary and a function, which you need to explicitly call to get the behavior.
- Also, I was testing this mostly with the ñ letter, and after all was implemented, I tried to create an incident with letters with accents (áéíóú) and it turns out we cannot create incidents with those letters :sob: (my gut feeling is because of channel names restrictions). We may want to look into that, of course, but as this work was already done, I think it's better to merge it and tackle that in the future.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-28332
