### PR TITLE
allow changing stages after incident is ended

### DIFF
--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -503,9 +503,7 @@ func (s *ServiceImpl) ChangeActiveStage(incidentID, userID string, stageIdx int)
 		return nil, err
 	}
 
-	if !incidentToModify.IsActive {
-		return nil, ErrIncidentNotActive
-	} else if incidentToModify.ActiveStage == stageIdx {
+	if incidentToModify.ActiveStage == stageIdx {
 		return incidentToModify, nil
 	}
 


### PR DESCRIPTION
#### Summary
For consistency with other fields on the RHS, allow changing state even after ending the incident.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28030