### PR TITLE
currentChannelId vs currentChannel.Id

### DIFF
--- a/webapp/src/hooks.ts
+++ b/webapp/src/hooks.ts
@@ -31,16 +31,17 @@ export function useCurrentIncident(): [Incident | null, CurrentIncidentState] {
     const [incident, setIncident] = useState<Incident | null>(null);
     const [state, setState] = useState<CurrentIncidentState>(CurrentIncidentState.Loading);
 
+    const currentChannelId = currentChannel?.id;
     useEffect(() => {
         const fetchIncident = async () => {
-            if (!currentChannel) {
+            if (!currentChannelId) {
                 setIncident(null);
                 setState(CurrentIncidentState.NotFound);
                 return;
             }
 
             try {
-                setIncident(await fetchIncidentByChannel(currentChannel.id));
+                setIncident(await fetchIncidentByChannel(currentChannelId));
                 setState(CurrentIncidentState.Loaded);
             } catch (err) {
                 if (err.status_code === 404) {
@@ -51,7 +52,7 @@ export function useCurrentIncident(): [Incident | null, CurrentIncidentState] {
         };
         setState(CurrentIncidentState.Loading);
         fetchIncident();
-    }, [currentChannel]);
+    }, [currentChannelId]);
 
     useEffect(() => {
         const doUpdate = (updatedIncident: Incident) => {


### PR DESCRIPTION
#### Summary
`currentChannel` from the Redux store is changing unexpectedly, even if the channel itself is not changing -- depend on `currentChannel.Id` only instead to avoid flashing the RHS until the webapp is fixed.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-28825