### PR TITLE
MM-28038: reset pagination on filtering

### DIFF
--- a/tests-e2e/cypress/integration/backstage/incident_list_spec.js
+++ b/tests-e2e/cypress/integration/backstage/incident_list_spec.js
@@ -6,6 +6,10 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
+const BACKSTAGE_LIST_PER_PAGE = 15;
+
+import {TINY} from '../../fixtures/timeouts';
+
 describe('backstage incident list', () => {
     const playbookName = 'Playbook (' + Date.now() + ')';
     let teamId;
@@ -77,5 +81,77 @@ describe('backstage incident list', () => {
 
         // * Verify that the header contains the incident name
         cy.findByTestId('incident-title').contains(incidentName);
+    });
+
+    describe('resets pagination when filtering', () => {
+        const incidentTimestamps = [];
+
+        before(() => {
+            // # Login as user-1
+            cy.apiLogin('user-1');
+
+            // # Start sufficient incidents to ensure pagination is possible.
+            for (let i = 0; i < BACKSTAGE_LIST_PER_PAGE + 1; i++) {
+                const now = Date.now();
+                cy.apiStartIncident({
+                    teamId,
+                    playbookId,
+                    incidentName: 'Incident (' + now + ')',
+                    commanderUserId: userId,
+                });
+                incidentTimestamps.push(now);
+            }
+        });
+
+        beforeEach(() => {
+            // # Login as user-1
+            cy.apiLogin('user-1');
+
+            // # Open backstage
+            cy.openBackstage();
+
+            // # Switch to incidents backstage
+            cy.findByTestId('incidentsLHSButton').click();
+
+            // # Switch to page 2
+            cy.findByText('Next').click();
+
+            // * Verify "Previous" now shown
+            cy.findByText('Previous').should('exist');
+        });
+
+        it('by incident name', () => {
+            // # Search for an incident by name
+            cy.get('#incidentList input').type(incidentTimestamps[0]);
+
+            // # Wait for the incident list to update.
+            cy.wait(TINY);
+
+            // * Verify "Previous" no longer shown
+            cy.findByText('Previous').should('not.exist');
+        });
+
+        it('by commander', () => {
+            cy.get('.profile-dropdown').
+                click().
+                find('.IncidentProfile').first().parent().click({force: true});
+
+            // # Wait for the incident list to update.
+            cy.wait(TINY);
+
+            // * Verify "Previous" no longer shown
+            cy.findByText('Previous').should('not.exist');
+        });
+
+        it('by status', () => {
+            cy.get('.status-filter-dropdown').click();
+            cy.get('.status-filter-dropdown').findByText('Ongoing').parent().click();
+
+            // # Wait for the incident list to update.
+            cy.wait(TINY);
+
+            // * Verify "Previous" no longer shown
+            cy.findByText('Previous').should('not.exist');
+        });
     });
 });

--- a/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
+++ b/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
@@ -69,11 +69,11 @@ const BackstageIncidentList: FC = () => {
     }, [fetchParams]);
 
     function setSearchTerm(term: string) {
-        setFetchParams({...fetchParams, search_term: term});
+        setFetchParams({...fetchParams, search_term: term, page: 0});
     }
 
     function setStatus(status: string) {
-        setFetchParams({...fetchParams, status});
+        setFetchParams({...fetchParams, status, page: 0});
     }
 
     function setPage(page: number) {
@@ -102,7 +102,7 @@ const BackstageIncidentList: FC = () => {
     }
 
     function setCommanderId(userId?: string) {
-        setFetchParams({...fetchParams, commander_user_id: userId});
+        setFetchParams({...fetchParams, commander_user_id: userId, page: 0});
     }
 
     function openIncidentDetails(incident: Incident) {


### PR DESCRIPTION
#### Summary
When changing the filter settings on the incident list, reset pagination to avoid being stuck on a second page without any results.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-28038