### PR TITLE
MM-28797 - Fix permissions in incidents and playbook

### DIFF
--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -1077,7 +1077,7 @@ func TestIncidents(t *testing.T) {
 
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
 		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_READ_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(false)
+		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
 		result := &incident.GetIncidentsResults{
 			TotalCount: 100,
 			PageCount:  200,
@@ -1111,16 +1111,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("get empty list of incidents", func(t *testing.T) {
 		reset()
 
-		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
-		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_READ_CHANNEL).Return(true)
 		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(false)
-		result := &incident.GetIncidentsResults{
-			TotalCount: 0,
-			PageCount:  0,
-			HasMore:    false,
-			Items:      nil,
-		}
-		incidentService.EXPECT().GetIncidents(gomock.Any(), gomock.Any()).Return(result, nil)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v1/incidents?team_id=non-existent", nil)
@@ -1130,18 +1121,7 @@ func TestIncidents(t *testing.T) {
 
 		resp := testrecorder.Result()
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-		var actualList incident.GetIncidentsResults
-		err = json.NewDecoder(resp.Body).Decode(&actualList)
-		require.NoError(t, err)
-		expectedList := incident.GetIncidentsResults{
-			TotalCount: 0,
-			PageCount:  0,
-			HasMore:    false,
-			Items:      []incident.Incident{},
-		}
-		assert.Equal(t, expectedList, actualList)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	})
 }
 

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -58,7 +58,7 @@ func (h *PlaybookHandler) createPlaybook(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if err := permissions.ViewTeam(userID, pbook.TeamID, h.pluginAPI); err != nil {
+	if !permissions.CanViewTeam(userID, pbook.TeamID, h.pluginAPI) {
 		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
 			"userID %s does not have permission to create playbook on teamID %s",
 			userID,
@@ -188,7 +188,7 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err2 := permissions.ViewTeam(userID, teamID, h.pluginAPI); err2 != nil {
+	if !permissions.CanViewTeam(userID, teamID, h.pluginAPI) {
 		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
 			"userID %s does not have permission to get playbooks on teamID %s",
 			userID,
@@ -198,10 +198,9 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requesterInfo := playbook.RequesterInfo{
-		UserID:              userID,
-		TeamID:              teamID,
-		UserIDtoIsAdmin:     map[string]bool{userID: permissions.IsAdmin(userID, h.pluginAPI)},
-		TeamIDtoCanViewTeam: map[string]bool{teamID: permissions.CanViewTeam(userID, teamID, h.pluginAPI)},
+		UserID:          userID,
+		TeamID:          teamID,
+		UserIDtoIsAdmin: map[string]bool{userID: permissions.IsAdmin(userID, h.pluginAPI)},
 	}
 
 	playbookResults, err := h.playbookService.GetPlaybooksForTeam(requesterInfo, teamID, opts)
@@ -224,7 +223,7 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *PlaybookHandler) hasPermissionsToPlaybook(thePlaybook playbook.Playbook, userID string) bool {
-	if err := permissions.ViewTeam(userID, thePlaybook.TeamID, h.pluginAPI); err != nil {
+	if !permissions.CanViewTeam(userID, thePlaybook.TeamID, h.pluginAPI) {
 		return false
 	}
 

--- a/server/api/playbooks_test.go
+++ b/server/api/playbooks_test.go
@@ -170,10 +170,9 @@ func TestPlaybooks(t *testing.T) {
 		playbookService.EXPECT().
 			GetPlaybooksForTeam(
 				playbook.RequesterInfo{
-					UserID:              "testuserid",
-					TeamID:              "testteamid",
-					UserIDtoIsAdmin:     map[string]bool{"testuserid": true},
-					TeamIDtoCanViewTeam: map[string]bool{"testteamid": true},
+					UserID:          "testuserid",
+					TeamID:          "testteamid",
+					UserIDtoIsAdmin: map[string]bool{"testuserid": true},
 				},
 				"testteamid",
 				gomock.Any(),
@@ -567,10 +566,9 @@ func TestPlaybooks(t *testing.T) {
 		playbookService.EXPECT().
 			GetPlaybooksForTeam(
 				playbook.RequesterInfo{
-					UserID:              "testuserid",
-					TeamID:              "testteamid",
-					UserIDtoIsAdmin:     map[string]bool{"testuserid": false},
-					TeamIDtoCanViewTeam: map[string]bool{"testteamid": true},
+					UserID:          "testuserid",
+					TeamID:          "testteamid",
+					UserIDtoIsAdmin: map[string]bool{"testuserid": false},
 				},
 				"testteamid",
 				gomock.Any(),
@@ -799,10 +797,9 @@ func TestSortingPlaybooks(t *testing.T) {
 			playbookService.EXPECT().
 				GetPlaybooksForTeam(
 					playbook.RequesterInfo{
-						UserID:              "testuserid",
-						TeamID:              "testteamid",
-						UserIDtoIsAdmin:     map[string]bool{"testuserid": true},
-						TeamIDtoCanViewTeam: map[string]bool{"testteamid": true},
+						UserID:          "testuserid",
+						TeamID:          "testteamid",
+						UserIDtoIsAdmin: map[string]bool{"testuserid": true},
 					},
 					"testteamid",
 					gomock.Any(),
@@ -1010,10 +1007,9 @@ func TestPagingPlaybooks(t *testing.T) {
 			playbookService.EXPECT().
 				GetPlaybooksForTeam(
 					playbook.RequesterInfo{
-						UserID:              "testuserid",
-						TeamID:              "testteamid",
-						UserIDtoIsAdmin:     map[string]bool{"testuserid": true},
-						TeamIDtoCanViewTeam: map[string]bool{"testteamid": true},
+						UserID:          "testuserid",
+						TeamID:          "testteamid",
+						UserIDtoIsAdmin: map[string]bool{"testuserid": true},
 					},
 					"testteamid",
 					gomock.Any(),

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -127,11 +127,15 @@ func (r *Runner) actionStart(args []string) {
 		postID = args[1]
 	}
 
+	if !permissions.CanViewTeam(r.args.UserId, r.args.TeamId, r.pluginAPI) {
+		r.postCommandResponse("Must be a member of the team to start incidents.")
+		return
+	}
+
 	requesterInfo := playbook.RequesterInfo{
-		UserID:              r.args.UserId,
-		TeamID:              r.args.TeamId,
-		UserIDtoIsAdmin:     map[string]bool{r.args.UserId: permissions.IsAdmin(r.args.UserId, r.pluginAPI)},
-		TeamIDtoCanViewTeam: map[string]bool{r.args.TeamId: permissions.CanViewTeam(r.args.UserId, r.args.TeamId, r.pluginAPI)},
+		UserID:          r.args.UserId,
+		TeamID:          r.args.TeamId,
+		UserIDtoIsAdmin: map[string]bool{r.args.UserId: permissions.IsAdmin(r.args.UserId, r.pluginAPI)},
 	}
 
 	playbooksResults, err := r.playbookService.GetPlaybooksForTeam(requesterInfo, r.args.TeamId,

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -79,10 +79,9 @@ type DialogState struct {
 // RequesterInfo holds the userID and teamID that this request is regarding, and permissions
 // for the user making the request
 type RequesterInfo struct {
-	UserID              string
-	TeamID              string
-	UserIDtoIsAdmin     map[string]bool
-	TeamIDtoCanViewTeam map[string]bool
+	UserID          string
+	TeamID          string
+	UserIDtoIsAdmin map[string]bool
 }
 
 // ErrNotFound used to indicate entity not found.

--- a/server/permissions/permissions.go
+++ b/server/permissions/permissions.go
@@ -81,15 +81,6 @@ func EditIncident(userID, incidentID string, pluginAPI *pluginapi.Client, incide
 	return ErrNoPermissions
 }
 
-// ViewTeam returns nil if the userID has permissions to view teamID
-func ViewTeam(userID, teamID string, pluginAPI *pluginapi.Client) error {
-	if pluginAPI.User.HasPermissionToTeam(userID, teamID, model.PERMISSION_LIST_TEAM_CHANNELS) {
-		return nil
-	}
-
-	return ErrNoPermissions
-}
-
 // CanViewTeam returns true if the userID has permissions to view teamID
 func CanViewTeam(userID, teamID string, pluginAPI *pluginapi.Client) bool {
 	return pluginAPI.User.HasPermissionToTeam(userID, teamID, model.PERMISSION_LIST_TEAM_CHANNELS)

--- a/server/playbook/playbook.go
+++ b/server/playbook/playbook.go
@@ -69,10 +69,9 @@ type GetPlaybooksResults struct {
 
 // RequesterInfo holds the userID and permissions for the user making the request
 type RequesterInfo struct {
-	UserID              string
-	TeamID              string
-	UserIDtoIsAdmin     map[string]bool
-	TeamIDtoCanViewTeam map[string]bool
+	UserID          string
+	TeamID          string
+	UserIDtoIsAdmin map[string]bool
 }
 
 // Service is the playbook service for managing playbooks

--- a/server/sqlstore/incident.go
+++ b/server/sqlstore/incident.go
@@ -325,8 +325,8 @@ func (s *incidentStore) buildPermissionsExpr(info incident.RequesterInfo) sq.Sql
 		return nil
 	}
 
-	if info.TeamIDtoCanViewTeam[info.TeamID] {
-		checkMembershipOrPublicChannel := sq.Expr(`
+	// is the requester a channel member, or is the channel public?
+	return sq.Expr(`
 		  (
 			  -- If requester is a channel member
 			  EXISTS(SELECT 1
@@ -339,17 +339,6 @@ func (s *incidentStore) buildPermissionsExpr(info incident.RequesterInfo) sq.Sql
 							WHERE c.Id = incident.ChannelID
 							  AND c.Type = 'O')
 		  )`, info.UserID)
-
-		return checkMembershipOrPublicChannel
-	}
-
-	return s.store.builder.
-		Select("1").
-		Prefix("EXISTS(").
-		From("ChannelMembers AS cm").
-		Where("cm.ChannelId = incident.ChannelID").
-		Where(sq.Eq{"cm.UserId": info.UserID}).
-		Suffix(")")
 }
 
 func toSQLIncident(origIncident incident.Incident) (*sqlIncident, error) {

--- a/server/sqlstore/incident_test.go
+++ b/server/sqlstore/incident_test.go
@@ -709,11 +709,10 @@ func TestGetIncidents(t *testing.T) {
 			ExpectedErr: nil,
 		},
 		{
-			Name: "team1 - Alice (in no channels but member of team, can see public incidents)",
+			Name: "team1 - Alice (in no channels but member of team (because request must have made it through the API team membership test to the store), can see public incidents)",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:              "Alice",
-				TeamID:              team1id,
-				TeamIDtoCanViewTeam: map[string]bool{team1id: true},
+				UserID: "Alice",
+				TeamID: team1id,
 			},
 			Options: incident.HeaderFilterOptions{
 				TeamID: team1id,
@@ -727,29 +726,10 @@ func TestGetIncidents(t *testing.T) {
 			ExpectedErr: nil,
 		},
 		{
-			Name: "team2 - Alice (in no channels and not member of team)",
+			Name: "team2 - Charlotte (in no channels but member of team -- because her request must have made it to the store through the API's team membership check)",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:              "Alice",
-				TeamID:              team2id,
-				TeamIDtoCanViewTeam: map[string]bool{team2id: false},
-			},
-			Options: incident.HeaderFilterOptions{
+				UserID: "Charlotte",
 				TeamID: team2id,
-			},
-			Want: incident.GetIncidentsResults{
-				TotalCount: 0,
-				PageCount:  0,
-				HasMore:    false,
-				Items:      nil,
-			},
-			ExpectedErr: nil,
-		},
-		{
-			Name: "team2 - Charlotte (in no channels but member of team)",
-			RequesterInfo: incident.RequesterInfo{
-				UserID:              "Charlotte",
-				TeamID:              team2id,
-				TeamIDtoCanViewTeam: map[string]bool{team2id: true},
 			},
 			Options: incident.HeaderFilterOptions{
 				TeamID: team2id,
@@ -783,9 +763,8 @@ func TestGetIncidents(t *testing.T) {
 
 		t.Run("zero incidents", func(t *testing.T) {
 			result, err := incidentStore.GetIncidents(incident.RequesterInfo{
-				UserID:              "Lucy",
-				TeamID:              team1id,
-				TeamIDtoCanViewTeam: map[string]bool{team1id: true},
+				UserID: "Lucy",
+				TeamID: team1id,
 			},
 				incident.HeaderFilterOptions{
 					TeamID:  team1id,
@@ -1155,44 +1134,10 @@ func TestGetCommanders(t *testing.T) {
 			ExpectedErr: nil,
 		},
 		{
-			Name: "team 1 - non-member",
+			Name: "team1 - Alice (in no channels but member of team (because must have made it through API team membership test), can see public incidents)",
 			RequesterInfo: incident.RequesterInfo{
-				UserID: "non-existing-id",
-			},
-			Options: incident.HeaderFilterOptions{
+				UserID: "Alice",
 				TeamID: team1id,
-			},
-			Expected:    nil,
-			ExpectedErr: nil,
-		},
-		{
-			Name: "team 2 - non-member",
-			RequesterInfo: incident.RequesterInfo{
-				UserID: "non-existing-id",
-			},
-			Options: incident.HeaderFilterOptions{
-				TeamID: team2id,
-			},
-			Expected:    nil,
-			ExpectedErr: nil,
-		},
-		{
-			Name: "team 3 - non-member",
-			RequesterInfo: incident.RequesterInfo{
-				UserID: "non-existing-id",
-			},
-			Options: incident.HeaderFilterOptions{
-				TeamID: team3id,
-			},
-			Expected:    nil,
-			ExpectedErr: nil,
-		},
-		{
-			Name: "team1 - Alice (in no channels but member of team, can see public incidents)",
-			RequesterInfo: incident.RequesterInfo{
-				UserID:              "Alice",
-				TeamID:              team1id,
-				TeamIDtoCanViewTeam: map[string]bool{team1id: true},
 			},
 			Options: incident.HeaderFilterOptions{
 				TeamID: team1id,
@@ -1201,22 +1146,10 @@ func TestGetCommanders(t *testing.T) {
 			ExpectedErr: nil,
 		},
 		{
-			Name: "team2 - Alice (in no channels and not member of team)",
+			Name: "team2 - Charlotte (in no channels but member of team, because must have made it through API team membership test)",
 			RequesterInfo: incident.RequesterInfo{
-				UserID: "Alice",
-			},
-			Options: incident.HeaderFilterOptions{
+				UserID: "Charlotte",
 				TeamID: team2id,
-			},
-			Expected:    nil,
-			ExpectedErr: nil,
-		},
-		{
-			Name: "team2 - Charlotte (in no channels but member of team)",
-			RequesterInfo: incident.RequesterInfo{
-				UserID:              "Charlotte",
-				TeamID:              team2id,
-				TeamIDtoCanViewTeam: map[string]bool{team2id: true},
 			},
 			Options: incident.HeaderFilterOptions{
 				TeamID: team2id,

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -267,17 +267,14 @@ func (p *playbookStore) buildPermissionsExpr(info playbook.RequesterInfo) sq.Sql
 		return nil
 	}
 
-	isPlaybookMember := p.store.builder.
+	// is the requester a member of the playbook?
+	return p.store.builder.
 		Select("1").
 		Prefix("EXISTS(").
 		From("IR_PlaybookMember as pm").
 		Where("pm.PlaybookID = p.ID").
 		Where(sq.Eq{"pm.MemberID": info.UserID}).
 		Suffix(")")
-
-	// For now, whether you can view team channels or not, if you are a playbook member
-	// then you can view the playbook.
-	return isPlaybookMember
 }
 
 // Update updates a playbook

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -223,9 +223,8 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			name:   "team1 from Andrew",
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
-				UserID:              "Andrew",
-				TeamID:              team1id,
-				TeamIDtoCanViewTeam: map[string]bool{team1id: true},
+				UserID: "Andrew",
+				TeamID: team1id,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortByTitle,
@@ -242,9 +241,8 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			name:   "team1 from jon",
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
-				UserID:              "jon",
-				TeamID:              team1id,
-				TeamIDtoCanViewTeam: map[string]bool{team1id: true},
+				UserID: "jon",
+				TeamID: team1id,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortByTitle,
@@ -261,9 +259,8 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			name:   "team1 from jon title desc",
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
-				UserID:              "jon",
-				TeamID:              team1id,
-				TeamIDtoCanViewTeam: map[string]bool{team1id: true},
+				UserID: "jon",
+				TeamID: team1id,
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortByTitle,
@@ -281,9 +278,8 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			name:   "team1 from jon sort by stages desc",
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
-				UserID:              "jon",
-				TeamID:              team1id,
-				TeamIDtoCanViewTeam: map[string]bool{team1id: true},
+				UserID: "jon",
+				TeamID: team1id,
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortByStages,
@@ -450,9 +446,8 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			name:   "team2 from Matt",
 			teamID: team2id,
 			requesterInfo: playbook.RequesterInfo{
-				UserID:              "Matt",
-				TeamID:              team2id,
-				TeamIDtoCanViewTeam: map[string]bool{team2id: true},
+				UserID: "Matt",
+				TeamID: team2id,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortByTitle,
@@ -469,9 +464,8 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			name:   "team3 from Andrew (not on team)",
 			teamID: team3id,
 			requesterInfo: playbook.RequesterInfo{
-				UserID:              "Andrew",
-				TeamID:              team3id,
-				TeamIDtoCanViewTeam: map[string]bool{team3id: true},
+				UserID: "Andrew",
+				TeamID: team3id,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortByTitle,


### PR DESCRIPTION
#### Summary
- Simplifying permissions checking. If the user is not a member of the team, they cannot list incidents or commanders.
- No need to check that permission in the SQl queries--if the query is running, assume the requester has access to that team.
- I thought about making a `handler.checkTeamPermissions` and put that in front of everything, but we're not always sending in the team_id in the params (and trying to get it through the incident id or the channel id would just complicate it -- let's keep doing that in the individual handler functions).

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-28797
