### PR TITLE
MM-28949 - Fix the GetPlaybooksForTeam when used for starting an incident

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -136,6 +136,7 @@ func (r *Runner) actionStart(args []string) {
 		UserID:          r.args.UserId,
 		TeamID:          r.args.TeamId,
 		UserIDtoIsAdmin: map[string]bool{r.args.UserId: permissions.IsAdmin(r.args.UserId, r.pluginAPI)},
+		MemberOnly:      true,
 	}
 
 	playbooksResults, err := r.playbookService.GetPlaybooksForTeam(requesterInfo, r.args.TeamId,

--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -759,10 +759,6 @@ func (s *ServiceImpl) newIncidentDialog(teamID, commanderID, postID, clientID st
 
 	var options []*model.PostActionOptions
 	for _, playbook := range playbooks {
-		if !canStartIncidentWithPlaybook(commanderID, playbook) {
-			continue
-		}
-
 		options = append(options, &model.PostActionOptions{
 			Text:  playbook.Title,
 			Value: playbook.ID,
@@ -852,15 +848,4 @@ func addRandomBits(name string) string {
 	}
 	randBits := model.NewId()
 	return fmt.Sprintf("%s-%s", name, randBits[:4])
-}
-
-func canStartIncidentWithPlaybook(userID string, pb playbook.Playbook) bool {
-	// Members of a playbook can use it to start incident
-	for _, memberID := range pb.MemberIDs {
-		if memberID == userID {
-			return true
-		}
-	}
-
-	return false
 }

--- a/server/playbook/playbook.go
+++ b/server/playbook/playbook.go
@@ -73,7 +73,7 @@ type RequesterInfo struct {
 	TeamID          string
 	UserIDtoIsAdmin map[string]bool
 
- 	// MemberOnly filters playbooks to those for which UserId is a member
+	// MemberOnly filters playbooks to those for which UserId is a member
 	MemberOnly bool
 }
 

--- a/server/playbook/playbook.go
+++ b/server/playbook/playbook.go
@@ -73,7 +73,7 @@ type RequesterInfo struct {
 	TeamID          string
 	UserIDtoIsAdmin map[string]bool
 
-	// MemberOnly when true will return playbooks only if the requester is a member of those playbooks.
+ 	// MemberOnly filters playbooks to those for which UserId is a member
 	MemberOnly bool
 }
 

--- a/server/playbook/playbook.go
+++ b/server/playbook/playbook.go
@@ -72,6 +72,9 @@ type RequesterInfo struct {
 	UserID          string
 	TeamID          string
 	UserIDtoIsAdmin map[string]bool
+
+	// MemberOnly when true will return playbooks only if the requester is a member of those playbooks.
+	MemberOnly bool
 }
 
 // Service is the playbook service for managing playbooks

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"strings"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-plugin-incident-response/server/bot"
@@ -152,28 +151,34 @@ func (p *playbookStore) Get(id string) (out playbook.Playbook, err error) {
 }
 
 // GetPlaybooks retrieves all playbooks that are not deleted.
-func (p *playbookStore) GetPlaybooks() (out []playbook.Playbook, err error) {
+func (p *playbookStore) GetPlaybooks() ([]playbook.Playbook, error) {
 	tx, err := p.store.db.Beginx()
 	if err != nil {
-		return out, errors.Wrap(err, "could not begin transaction")
+		return nil, errors.Wrap(err, "could not begin transaction")
 	}
 	defer p.store.finalizeTransaction(tx)
 
-	err = p.store.selectBuilder(tx, &out, p.playbookSelect.Where(sq.Eq{"DeleteAt": 0}))
+	var out []playbook.Playbook
+	err = p.store.selectBuilder(tx, &out, p.store.builder.
+		Select("ID", "Title", "Description", "TeamID", "CreatePublicIncident", "CreateAt",
+			"DeleteAt", "NumStages", "NumSteps").
+		From("IR_Playbook AS p").
+		Where(sq.Eq{"DeleteAt": 0}))
+
 	if err == sql.ErrNoRows {
-		return out, errors.Wrap(playbook.ErrNotFound, "no playbooks found")
+		return nil, errors.Wrap(playbook.ErrNotFound, "no playbooks found")
 	} else if err != nil {
-		return out, errors.Wrap(err, "failed to get playbooks")
+		return nil, errors.Wrap(err, "failed to get playbooks")
 	}
 
 	var memberIDs playbookMembers
 	err = p.store.selectBuilder(tx, &memberIDs, p.memberIDsSelect)
 	if err != nil && err != sql.ErrNoRows {
-		return out, errors.Wrapf(err, "failed to get memberIDs")
+		return nil, errors.Wrapf(err, "failed to get memberIDs")
 	}
 
 	if err = tx.Commit(); err != nil {
-		return out, errors.Wrap(err, "could not commit transaction")
+		return nil, errors.Wrap(err, "could not commit transaction")
 	}
 
 	addMembersToPlaybooks(memberIDs, out)
@@ -183,33 +188,14 @@ func (p *playbookStore) GetPlaybooks() (out []playbook.Playbook, err error) {
 
 // GetPlaybooksForTeam retrieves all playbooks on the specified team given the provided options.
 func (p *playbookStore) GetPlaybooksForTeam(requesterInfo playbook.RequesterInfo, teamID string, opts playbook.Options) (playbook.GetPlaybooksResults, error) {
-	getMembers := `
-			(SELECT PlaybookID, string_agg(MemberID, ' ') members
-			   FROM IR_PlaybookMember
-			   GROUP BY PlaybookID
-			) pmember
-			ON p.ID = pmember.PlaybookID
-		`
-
-	if p.store.db.DriverName() == model.DATABASE_DRIVER_MYSQL {
-		getMembers = `
-				(SELECT PlaybookID, GROUP_CONCAT(MemberID SEPARATOR ' ') members
-				   FROM IR_PlaybookMember
-				   GROUP BY PlaybookID
-				) pmember
-				ON p.ID = pmember.PlaybookID
-			`
-	}
-
 	permissionsExpr := p.buildPermissionsExpr(requesterInfo)
 
 	correctPaginationOpts(&opts)
 
 	queryForResults := p.store.builder.
 		Select("ID", "Title", "Description", "TeamID", "CreatePublicIncident", "CreateAt",
-			"DeleteAt", "NumStages", "NumSteps", "pmember.Members").
+			"DeleteAt", "NumStages", "NumSteps").
 		From("IR_Playbook AS p").
-		Join(getMembers).
 		Where(sq.Eq{"DeleteAt": 0}).
 		Where(sq.Eq{"TeamID": teamID}).
 		Where(permissionsExpr).
@@ -222,11 +208,8 @@ func (p *playbookStore) GetPlaybooksForTeam(requesterInfo playbook.RequesterInfo
 		queryForResults = queryForResults.OrderBy(sortOptionToSQL(opts.Sort))
 	}
 
-	var playbookWithMembers []struct {
-		playbook.Playbook
-		Members string
-	}
-	err := p.store.selectBuilder(p.store.db, &playbookWithMembers, queryForResults)
+	var playbooks []playbook.Playbook
+	err := p.store.selectBuilder(p.store.db, &playbooks, queryForResults)
 	if err == sql.ErrNoRows {
 		return playbook.GetPlaybooksResults{}, errors.Wrap(playbook.ErrNotFound, "no playbooks found")
 	} else if err != nil {
@@ -236,7 +219,6 @@ func (p *playbookStore) GetPlaybooksForTeam(requesterInfo playbook.RequesterInfo
 	queryForTotal := p.store.builder.
 		Select("COUNT(*)").
 		From("IR_Playbook AS p").
-		Join(getMembers).
 		Where(sq.Eq{"DeleteAt": 0}).
 		Where(sq.Eq{"TeamID": teamID}).
 		Where(permissionsExpr)
@@ -248,12 +230,6 @@ func (p *playbookStore) GetPlaybooksForTeam(requesterInfo playbook.RequesterInfo
 	pageCount := int(math.Ceil(float64(total) / float64(opts.PerPage)))
 	hasMore := opts.Page+1 < pageCount
 
-	playbooks := make([]playbook.Playbook, 0, len(playbookWithMembers))
-	for _, p := range playbookWithMembers {
-		p.Playbook.MemberIDs = strings.Fields(p.Members)
-		playbooks = append(playbooks, p.Playbook)
-	}
-
 	return playbook.GetPlaybooksResults{
 		TotalCount: total,
 		PageCount:  pageCount,
@@ -263,7 +239,7 @@ func (p *playbookStore) GetPlaybooksForTeam(requesterInfo playbook.RequesterInfo
 }
 
 func (p *playbookStore) buildPermissionsExpr(info playbook.RequesterInfo) sq.Sqlizer {
-	if info.UserIDtoIsAdmin[info.UserID] {
+	if info.UserIDtoIsAdmin[info.UserID] && !info.MemberOnly {
 		return nil
 	}
 

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -35,7 +35,7 @@ var (
 		WithTeamID(team1id).
 		WithChecklists([]int{1, 2, 3}).
 		WithCreateAt(700).
-		WithMembers([]string{"jon", "Matt"}).
+		WithMembers([]string{"jon", "Matt", "Lucy"}).
 		ToPlaybook()
 
 	pb04 = NewPBBuilder().
@@ -72,11 +72,11 @@ var (
 		ToPlaybook()
 
 	pb08 = NewPBBuilder().
-		WithTitle("playbook 8 -- so many members, but should have Desmond").
+		WithTitle("playbook 8 -- so many members, but should have Desmond and Lucy").
 		WithTeamID(team3id).
 		WithCreateAt(1300).
 		WithChecklists([]int{1}).
-		WithMembers([]string{"km69ab3boj1w6ft9mh83wao7qk", "48wthyysxrhhs3ww4mnnfmg1bn", "1sziwjjsxfe5iez9puk8dtrd6f", "dir7jfkho1dnna3frw96ahhp46", "bx4omgdi1exgpn155hs89trres", "g3gc8s63pnaxqf3q5bm3jq3itc", "ripkmp6wjxsrb6nctri3z96wga", "3xh8nxhp1asz3deb1gjcrotrhm", "8xig6s3465xyg7bsptdtu3b4dc", "mbrhcb57zpm1f7mtxewjwjux17", "hum776w1fsiqq6dgc9561pspjh", "ty7yisf6uohztcneox1swfmktz", "u68r5j1dyrn1rdemffwesh4mt4", "9w1sxocjx81pcd3gpbs3zhz5r5", "a5um18y94q9eurndefh78m4r1g", "bo7bx1entxw3nuizc1qg3r48oy", "x7cbowuxdykm7ytukdimnqji6c", "gdsnue5o8r4m6wfntsooff477s", "pp4oezhq9iw7rkzfercwx14i8i", "94idra7dufbzyjf4u1pte3hkr7", "ybz1okk7xwhop8abwehhep1aku", "yimdy1t684zbjowpbuiduwwodj", "9o1sennwafq93mfktesq3u148k", "wx53zae8f65dapqsyosrna8ut5", "w6myqcskkm8i8o9irdreuph56w", "3q7tmspxz19z69prdkarbdt3p8", "7ctuig4u1ufua6nssidpgr6ewq", "hkuxd5ek95y9taoxik9p64asf3", "zjj46gmzu13jjn5fqd94bp5u1a", "ujziq8brph9jiofzer9xnrf7mn", "cz8geybczsqntb7knr69rtwjfd", "rz4o3ma9z9wddcemxx45nzn8ww", "tusurxfzphgu9mn8p1x5yx6jrk", "17j5mienxuoiwuakmy1o5d7ib3", "9a3wbd837n8na6mwbnt14kkbpq", "nqo7mcziz9ziw5s3fs1ef1ijk4", "ynomnwu6w3d1ukdb4m5r16t1gz", "dhb4zk1yixrwjd677co3dskfab", "w4fktm4688grn5uujw5uazi6z1", "e8tpfuwhfcma1max7ecudewore", "tm7d9bpawauot1zmzmrebppauq", "8kr759nfjtxa6hictg3asgxig6", "1kjiu1wcm4hwhfjpagzwf4t7n3", "brhambc1te8z53emhgupa8kzpd", "m4ss9t7qq67b4jc5dnfrseqep6", "zikhetznm4a8mrf49ugm7tozqw", "u7571bbcmx8npcmd5566m5ukb6", "h4n4mre1dfuqycmfbieogifkot", "uy3n7pqxexm1zwzfznd7eaaxzd", "gtam6jfecsbz3rjdeaqrd7x9ug", "o3f49i6pj1o5f64zc4iwggodfp", "oxd5unhuobn7wwcaeqnwsdsu66", "gfaht9zz684qeaj5sp15f47wjh", "i66ra6qgri3qrdhq5f8qck4ph6", "9m6qrptdhgmcuz99x67x6u961u", "5u1o88mksy8rb7u4icwugmxbe1", "ndr7ynmqma9xdpmopydwpmgo3t", "idh3obto6pgqyyqyip7ccz1ofw", "f6ttuh1fib1z7ojn7m4k4ibfaj", "g5gy4ftagxxsg3oui8gje7bzs3", "bin6rum17mnkfdthwyacur54zb", "ubmprty7n17rujuz54ftt14fjq", "w4orazbza9fdky5xnf3134fhr6", "g9h113mgki94znn5yqxub3ag6d", "az17h8jcpyc1g18cngr9smts1h", "ik7bcdgsed9zg1k9h1of3ajyf1", "ams86onzsc438xrrtngjqd6ifd", "8y7ndwcrmtyeii4zyohbgy3kbx", "wag85ck6ywy6zo4mqpbim91kys", "iocdaqbuhgtwrzipp8kx17ebf9", "871rg1i4hboxcwdk4x65d7nbmc", "6eu6bpbo9g6my1pd4qnwbzbnff", "71suj8gdmzcukfqq9afoym8qm3", "ckmbrttb1kduukdgq8gboyk1zf", "cyyoh9rcuf6pm6xdrdf84qqwzk", "w1nr1cayrh5esp83a4mzppn3nw", "u1479anr9ergdf99mz6ofhi48n", "1khpthie5h7oapxtmqpuqdqkod", "t9eocsfwod3k3bbdga33k9uet4", "k5t8c41bbrko75knjh8zepkd3z", "1nky9tsw3k9nnwhyu38pcnoqfm", "rz8d3ke4j44hf6nabyc7wbgoft", "eri48z5ektr1b7xkr9sy17ao1i", "wibzmdmo1q1jjz4hapsout7geh", "b7nx3itj6nghd54u3gzy5ndj93", "i5r7fazxp31ddixiiwne1bhpaa", "z484cdy4e6gszik74myr5mcg4e", "8xb55g14qtuyih6ojnw4eptway", "djsmuoqhrj58jkonyh1pnp64f1", "t6cha81jkc5fhow3k3xbbbjis8", "ohwu5rut5j3shohaa8tz9p4hjx", "1t3wp8a63jpgpij9wxq83w98aq", "fjx4wargux3smyafn83q55qo8a", "n5hpf9cuskzpks57e145yi8u6q", "k9x35pzo5rq7tce5ob8uggs5x5", "u3c9yikcmy1tgooujkg4i5awuy", "tmmk74jhdz3mmnm6iehk5d48ic", "jwa9rumxk5zeknjdn11pq3mnyz", "87bratz37jt7s8bcg14tftydar", "gynarn89deddsoedut4yg4458s", "Desmond"}).
+		WithMembers([]string{"km69ab3boj1w6ft9mh83wao7qk", "48wthyysxrhhs3ww4mnnfmg1bn", "1sziwjjsxfe5iez9puk8dtrd6f", "dir7jfkho1dnna3frw96ahhp46", "bx4omgdi1exgpn155hs89trres", "g3gc8s63pnaxqf3q5bm3jq3itc", "ripkmp6wjxsrb6nctri3z96wga", "3xh8nxhp1asz3deb1gjcrotrhm", "8xig6s3465xyg7bsptdtu3b4dc", "mbrhcb57zpm1f7mtxewjwjux17", "hum776w1fsiqq6dgc9561pspjh", "ty7yisf6uohztcneox1swfmktz", "u68r5j1dyrn1rdemffwesh4mt4", "9w1sxocjx81pcd3gpbs3zhz5r5", "a5um18y94q9eurndefh78m4r1g", "bo7bx1entxw3nuizc1qg3r48oy", "x7cbowuxdykm7ytukdimnqji6c", "gdsnue5o8r4m6wfntsooff477s", "pp4oezhq9iw7rkzfercwx14i8i", "94idra7dufbzyjf4u1pte3hkr7", "ybz1okk7xwhop8abwehhep1aku", "yimdy1t684zbjowpbuiduwwodj", "9o1sennwafq93mfktesq3u148k", "wx53zae8f65dapqsyosrna8ut5", "w6myqcskkm8i8o9irdreuph56w", "3q7tmspxz19z69prdkarbdt3p8", "7ctuig4u1ufua6nssidpgr6ewq", "hkuxd5ek95y9taoxik9p64asf3", "zjj46gmzu13jjn5fqd94bp5u1a", "ujziq8brph9jiofzer9xnrf7mn", "cz8geybczsqntb7knr69rtwjfd", "rz4o3ma9z9wddcemxx45nzn8ww", "tusurxfzphgu9mn8p1x5yx6jrk", "17j5mienxuoiwuakmy1o5d7ib3", "9a3wbd837n8na6mwbnt14kkbpq", "nqo7mcziz9ziw5s3fs1ef1ijk4", "ynomnwu6w3d1ukdb4m5r16t1gz", "dhb4zk1yixrwjd677co3dskfab", "w4fktm4688grn5uujw5uazi6z1", "e8tpfuwhfcma1max7ecudewore", "tm7d9bpawauot1zmzmrebppauq", "8kr759nfjtxa6hictg3asgxig6", "1kjiu1wcm4hwhfjpagzwf4t7n3", "brhambc1te8z53emhgupa8kzpd", "m4ss9t7qq67b4jc5dnfrseqep6", "zikhetznm4a8mrf49ugm7tozqw", "u7571bbcmx8npcmd5566m5ukb6", "h4n4mre1dfuqycmfbieogifkot", "uy3n7pqxexm1zwzfznd7eaaxzd", "gtam6jfecsbz3rjdeaqrd7x9ug", "o3f49i6pj1o5f64zc4iwggodfp", "oxd5unhuobn7wwcaeqnwsdsu66", "gfaht9zz684qeaj5sp15f47wjh", "i66ra6qgri3qrdhq5f8qck4ph6", "9m6qrptdhgmcuz99x67x6u961u", "5u1o88mksy8rb7u4icwugmxbe1", "ndr7ynmqma9xdpmopydwpmgo3t", "idh3obto6pgqyyqyip7ccz1ofw", "f6ttuh1fib1z7ojn7m4k4ibfaj", "g5gy4ftagxxsg3oui8gje7bzs3", "bin6rum17mnkfdthwyacur54zb", "ubmprty7n17rujuz54ftt14fjq", "w4orazbza9fdky5xnf3134fhr6", "g9h113mgki94znn5yqxub3ag6d", "az17h8jcpyc1g18cngr9smts1h", "ik7bcdgsed9zg1k9h1of3ajyf1", "ams86onzsc438xrrtngjqd6ifd", "8y7ndwcrmtyeii4zyohbgy3kbx", "wag85ck6ywy6zo4mqpbim91kys", "iocdaqbuhgtwrzipp8kx17ebf9", "871rg1i4hboxcwdk4x65d7nbmc", "6eu6bpbo9g6my1pd4qnwbzbnff", "71suj8gdmzcukfqq9afoym8qm3", "ckmbrttb1kduukdgq8gboyk1zf", "cyyoh9rcuf6pm6xdrdf84qqwzk", "w1nr1cayrh5esp83a4mzppn3nw", "u1479anr9ergdf99mz6ofhi48n", "1khpthie5h7oapxtmqpuqdqkod", "t9eocsfwod3k3bbdga33k9uet4", "k5t8c41bbrko75knjh8zepkd3z", "1nky9tsw3k9nnwhyu38pcnoqfm", "rz8d3ke4j44hf6nabyc7wbgoft", "eri48z5ektr1b7xkr9sy17ao1i", "wibzmdmo1q1jjz4hapsout7geh", "b7nx3itj6nghd54u3gzy5ndj93", "i5r7fazxp31ddixiiwne1bhpaa", "z484cdy4e6gszik74myr5mcg4e", "8xb55g14qtuyih6ojnw4eptway", "djsmuoqhrj58jkonyh1pnp64f1", "t6cha81jkc5fhow3k3xbbbjis8", "ohwu5rut5j3shohaa8tz9p4hjx", "1t3wp8a63jpgpij9wxq83w98aq", "fjx4wargux3smyafn83q55qo8a", "n5hpf9cuskzpks57e145yi8u6q", "k9x35pzo5rq7tce5ob8uggs5x5", "u3c9yikcmy1tgooujkg4i5awuy", "tmmk74jhdz3mmnm6iehk5d48ic", "jwa9rumxk5zeknjdn11pq3mnyz", "87bratz37jt7s8bcg14tftydar", "gynarn89deddsoedut4yg4458s", "Desmond", "Lucy"}).
 		ToPlaybook()
 
 	pb = []playbook.Playbook{pb01, pb02, pb03, pb04, pb05, pb06, pb07, pb08}
@@ -345,6 +345,25 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name:   "team1 from Admin, member only",
+			teamID: team1id,
+			requesterInfo: playbook.RequesterInfo{
+				UserID:          "Lucy",
+				UserIDtoIsAdmin: map[string]bool{"Lucy": true},
+				MemberOnly:      true,
+			},
+			options: playbook.Options{
+				Sort: playbook.SortByTitle,
+			},
+			expected: playbook.GetPlaybooksResults{
+				TotalCount: 1,
+				PageCount:  1,
+				HasMore:    false,
+				Items:      []playbook.Playbook{pb03},
+			},
+			expectedErr: nil,
+		},
+		{
 			name:   "team1 from Admin sort by steps desc",
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
@@ -526,6 +545,25 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 				PageCount:  1,
 				HasMore:    false,
 				Items:      []playbook.Playbook{pb07, pb08},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:   "team3 from Admin, memberOnly",
+			teamID: team3id,
+			requesterInfo: playbook.RequesterInfo{
+				UserID:          "Lucy",
+				UserIDtoIsAdmin: map[string]bool{"Lucy": true},
+				MemberOnly:      true,
+			},
+			options: playbook.Options{
+				Sort: playbook.SortByTitle,
+			},
+			expected: playbook.GetPlaybooksResults{
+				TotalCount: 1,
+				PageCount:  1,
+				HasMore:    false,
+				Items:      []playbook.Playbook{pb08},
 			},
 			expectedErr: nil,
 		},

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -49,39 +49,39 @@ var (
 
 	pb05 = NewPBBuilder().
 		WithTitle("playbook 5").
-		WithDescription("this won't get returned because there are no members").
-		WithTeamID(team1id).
-		WithCreateAt(900).
-		WithChecklists([]int{1, 2, 40}).
-		ToPlaybook()
-
-	pb06 = NewPBBuilder().
-		WithTitle("playbook 6").
 		WithTeamID(team2id).
 		WithCreateAt(1000).
 		WithChecklists([]int{1}).
 		WithMembers([]string{"jon", "Andrew"}).
 		ToPlaybook()
 
-	pb07 = NewPBBuilder().
-		WithTitle("playbook 7").
+	pb06 = NewPBBuilder().
+		WithTitle("playbook 6").
 		WithTeamID(team2id).
 		WithCreateAt(1100).
 		WithChecklists([]int{1, 2, 3}).
 		WithMembers([]string{"Matt"}).
 		ToPlaybook()
 
-	pb08 = NewPBBuilder().
-		WithTitle("playbook 8").
+	pb07 = NewPBBuilder().
+		WithTitle("playbook 7").
 		WithTeamID(team3id).
 		WithCreateAt(1200).
 		WithChecklists([]int{1}).
 		WithMembers([]string{"Andrew"}).
 		ToPlaybook()
 
+	pb08 = NewPBBuilder().
+		WithTitle("playbook 8 -- so many members, but should have Desmond").
+		WithTeamID(team3id).
+		WithCreateAt(1300).
+		WithChecklists([]int{1}).
+		WithMembers([]string{"km69ab3boj1w6ft9mh83wao7qk", "48wthyysxrhhs3ww4mnnfmg1bn", "1sziwjjsxfe5iez9puk8dtrd6f", "dir7jfkho1dnna3frw96ahhp46", "bx4omgdi1exgpn155hs89trres", "g3gc8s63pnaxqf3q5bm3jq3itc", "ripkmp6wjxsrb6nctri3z96wga", "3xh8nxhp1asz3deb1gjcrotrhm", "8xig6s3465xyg7bsptdtu3b4dc", "mbrhcb57zpm1f7mtxewjwjux17", "hum776w1fsiqq6dgc9561pspjh", "ty7yisf6uohztcneox1swfmktz", "u68r5j1dyrn1rdemffwesh4mt4", "9w1sxocjx81pcd3gpbs3zhz5r5", "a5um18y94q9eurndefh78m4r1g", "bo7bx1entxw3nuizc1qg3r48oy", "x7cbowuxdykm7ytukdimnqji6c", "gdsnue5o8r4m6wfntsooff477s", "pp4oezhq9iw7rkzfercwx14i8i", "94idra7dufbzyjf4u1pte3hkr7", "ybz1okk7xwhop8abwehhep1aku", "yimdy1t684zbjowpbuiduwwodj", "9o1sennwafq93mfktesq3u148k", "wx53zae8f65dapqsyosrna8ut5", "w6myqcskkm8i8o9irdreuph56w", "3q7tmspxz19z69prdkarbdt3p8", "7ctuig4u1ufua6nssidpgr6ewq", "hkuxd5ek95y9taoxik9p64asf3", "zjj46gmzu13jjn5fqd94bp5u1a", "ujziq8brph9jiofzer9xnrf7mn", "cz8geybczsqntb7knr69rtwjfd", "rz4o3ma9z9wddcemxx45nzn8ww", "tusurxfzphgu9mn8p1x5yx6jrk", "17j5mienxuoiwuakmy1o5d7ib3", "9a3wbd837n8na6mwbnt14kkbpq", "nqo7mcziz9ziw5s3fs1ef1ijk4", "ynomnwu6w3d1ukdb4m5r16t1gz", "dhb4zk1yixrwjd677co3dskfab", "w4fktm4688grn5uujw5uazi6z1", "e8tpfuwhfcma1max7ecudewore", "tm7d9bpawauot1zmzmrebppauq", "8kr759nfjtxa6hictg3asgxig6", "1kjiu1wcm4hwhfjpagzwf4t7n3", "brhambc1te8z53emhgupa8kzpd", "m4ss9t7qq67b4jc5dnfrseqep6", "zikhetznm4a8mrf49ugm7tozqw", "u7571bbcmx8npcmd5566m5ukb6", "h4n4mre1dfuqycmfbieogifkot", "uy3n7pqxexm1zwzfznd7eaaxzd", "gtam6jfecsbz3rjdeaqrd7x9ug", "o3f49i6pj1o5f64zc4iwggodfp", "oxd5unhuobn7wwcaeqnwsdsu66", "gfaht9zz684qeaj5sp15f47wjh", "i66ra6qgri3qrdhq5f8qck4ph6", "9m6qrptdhgmcuz99x67x6u961u", "5u1o88mksy8rb7u4icwugmxbe1", "ndr7ynmqma9xdpmopydwpmgo3t", "idh3obto6pgqyyqyip7ccz1ofw", "f6ttuh1fib1z7ojn7m4k4ibfaj", "g5gy4ftagxxsg3oui8gje7bzs3", "bin6rum17mnkfdthwyacur54zb", "ubmprty7n17rujuz54ftt14fjq", "w4orazbza9fdky5xnf3134fhr6", "g9h113mgki94znn5yqxub3ag6d", "az17h8jcpyc1g18cngr9smts1h", "ik7bcdgsed9zg1k9h1of3ajyf1", "ams86onzsc438xrrtngjqd6ifd", "8y7ndwcrmtyeii4zyohbgy3kbx", "wag85ck6ywy6zo4mqpbim91kys", "iocdaqbuhgtwrzipp8kx17ebf9", "871rg1i4hboxcwdk4x65d7nbmc", "6eu6bpbo9g6my1pd4qnwbzbnff", "71suj8gdmzcukfqq9afoym8qm3", "ckmbrttb1kduukdgq8gboyk1zf", "cyyoh9rcuf6pm6xdrdf84qqwzk", "w1nr1cayrh5esp83a4mzppn3nw", "u1479anr9ergdf99mz6ofhi48n", "1khpthie5h7oapxtmqpuqdqkod", "t9eocsfwod3k3bbdga33k9uet4", "k5t8c41bbrko75knjh8zepkd3z", "1nky9tsw3k9nnwhyu38pcnoqfm", "rz8d3ke4j44hf6nabyc7wbgoft", "eri48z5ektr1b7xkr9sy17ao1i", "wibzmdmo1q1jjz4hapsout7geh", "b7nx3itj6nghd54u3gzy5ndj93", "i5r7fazxp31ddixiiwne1bhpaa", "z484cdy4e6gszik74myr5mcg4e", "8xb55g14qtuyih6ojnw4eptway", "djsmuoqhrj58jkonyh1pnp64f1", "t6cha81jkc5fhow3k3xbbbjis8", "ohwu5rut5j3shohaa8tz9p4hjx", "1t3wp8a63jpgpij9wxq83w98aq", "fjx4wargux3smyafn83q55qo8a", "n5hpf9cuskzpks57e145yi8u6q", "k9x35pzo5rq7tce5ob8uggs5x5", "u3c9yikcmy1tgooujkg4i5awuy", "tmmk74jhdz3mmnm6iehk5d48ic", "jwa9rumxk5zeknjdn11pq3mnyz", "87bratz37jt7s8bcg14tftydar", "gynarn89deddsoedut4yg4458s", "Desmond"}).
+		ToPlaybook()
+
 	pb = []playbook.Playbook{pb01, pb02, pb03, pb04, pb05, pb06, pb07, pb08}
 
-	users = []string{"jon", "Andrew", "Matt", "Lucy"}
+	users = []string{"jon", "Andrew", "Matt", "Lucy", "Desmond"}
 )
 
 func TestGetPlaybook(t *testing.T) {
@@ -105,6 +105,25 @@ func TestGetPlaybook(t *testing.T) {
 			actual, err := playbookStore.Get(id)
 			require.NoError(t, err)
 			require.Equal(t, expected, actual)
+		})
+
+		t.Run(driverName+" - create and retrieve all playbooks", func(t *testing.T) {
+			var inserted []playbook.Playbook
+			for _, p := range pb {
+				id, err := playbookStore.Create(p)
+				require.NoError(t, err)
+
+				tmp := p.Clone()
+				tmp.ID = id
+				inserted = append(inserted, tmp)
+			}
+
+			for _, p := range inserted {
+				got, err := playbookStore.Get(p.ID)
+				require.NoError(t, err)
+				require.Equal(t, p, got)
+			}
+			require.Equal(t, len(pb), len(inserted))
 		})
 
 		t.Run(driverName+" - create but retrieve non-existing playbook", func(t *testing.T) {
@@ -138,15 +157,6 @@ func TestGetPlaybook(t *testing.T) {
 }
 
 func TestGetPlaybooks(t *testing.T) {
-	createPlaybooks := func(store playbook.Store) {
-		t.Helper()
-
-		for i := range pb {
-			_, err := store.Create(pb[i])
-			require.NoError(t, err)
-		}
-	}
-
 	tests := []struct {
 		name        string
 		expected    []playbook.Playbook
@@ -154,7 +164,7 @@ func TestGetPlaybooks(t *testing.T) {
 	}{
 		{
 			name:        "get all playbooks",
-			expected:    []playbook.Playbook{pb01, pb02, pb03, pb04, pb05, pb06, pb07, pb08},
+			expected:    pb,
 			expectedErr: nil,
 		},
 	}
@@ -169,7 +179,27 @@ func TestGetPlaybooks(t *testing.T) {
 			require.ElementsMatch(t, []playbook.Playbook{}, result)
 		})
 
-		createPlaybooks(playbookStore)
+		// create playbooks, test that they were created correctly
+		all, err := playbookStore.GetPlaybooks()
+		require.NoError(t, err)
+		require.Equal(t, 0, len(all))
+
+		var inserted []playbook.Playbook
+		for _, p := range pb {
+			id, err := playbookStore.Create(p)
+			require.NoError(t, err)
+
+			tmp := p.Clone()
+			tmp.ID = id
+			inserted = append(inserted, tmp)
+		}
+
+		for _, p := range inserted {
+			got, err := playbookStore.Get(p.ID)
+			require.NoError(t, err)
+			require.Equal(t, p, got)
+		}
+		require.Equal(t, len(pb), len(inserted))
 
 		for _, testCase := range tests {
 			t.Run(driverName+" - "+testCase.name, func(t *testing.T) {
@@ -191,11 +221,14 @@ func TestGetPlaybooks(t *testing.T) {
 				}
 
 				// remove the checklists from the expected playbooks--we don't return them in getPlaybooks
-				for i := range testCase.expected {
-					testCase.expected[i].Checklists = []playbook.Checklist(nil)
+				var expected []playbook.Playbook
+				for _, p := range testCase.expected {
+					tmp := p.Clone()
+					tmp.Checklists = nil
+					expected = append(expected, tmp)
 				}
 
-				require.ElementsMatch(t, testCase.expected, actual)
+				require.ElementsMatch(t, expected, actual)
 			})
 		}
 	}
@@ -456,7 +489,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 				TotalCount: 1,
 				PageCount:  1,
 				HasMore:    false,
-				Items:      []playbook.Playbook{pb07},
+				Items:      []playbook.Playbook{pb06},
 			},
 			expectedErr: nil,
 		},
@@ -474,7 +507,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 				TotalCount: 1,
 				PageCount:  1,
 				HasMore:    false,
-				Items:      []playbook.Playbook{pb08},
+				Items:      []playbook.Playbook{pb07},
 			},
 			expectedErr: nil,
 		},
@@ -484,6 +517,24 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          "Lucy",
 				UserIDtoIsAdmin: map[string]bool{"Lucy": true},
+			},
+			options: playbook.Options{
+				Sort: playbook.SortByTitle,
+			},
+			expected: playbook.GetPlaybooksResults{
+				TotalCount: 2,
+				PageCount:  1,
+				HasMore:    false,
+				Items:      []playbook.Playbook{pb07, pb08},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:   "team3 from Desmond - testing many members",
+			teamID: team3id,
+			requesterInfo: playbook.RequesterInfo{
+				UserID: "Desmond",
+				TeamID: team3id,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortByTitle,
@@ -503,7 +554,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 				TotalCount: 0,
 				PageCount:  0,
 				HasMore:    false,
-				Items:      []playbook.Playbook{},
+				Items:      nil,
 			},
 			expectedErr: nil,
 		},
@@ -548,9 +599,10 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 					actual.Items[i].ID = ""
 				}
 
-				// remove the checklists from the expected playbooks--we don't return them in getPlaybooks
+				// remove the checklists and members from the expected playbooks--we don't return them in getPlaybooks
 				for i := range testCase.expected.Items {
-					testCase.expected.Items[i].Checklists = []playbook.Checklist(nil)
+					testCase.expected.Items[i].Checklists = nil
+					testCase.expected.Items[i].MemberIDs = nil
 				}
 
 				require.Equal(t, testCase.expected, actual)


### PR DESCRIPTION
#### Summary
- Simplify the GetPlaybooksForTeams. We could have put the MemberOnly flag in the options, but I figured that should probably be kept for paging and searching options, the kind that are sent from the client, whereas RequesterInfo is more of the internal information. But I'm open to other suggestions. 
- Had a lot of trouble with the tests, that's what took half the day. Turns out I was modifying the original slice of playbooks, and then inserting them again into the next db, and that's why things were failing. It was a mess.
- Alternatively, we could get all memberIDs like in `GetPlaybooks` and keep the check in the Go code, but keeping it all in the store seems cleaner to me.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-28994