### PR TITLE
MM-29021: Fix timestamp bug in data migration

### DIFF
--- a/server/sqlstore/data_migration_test.go
+++ b/server/sqlstore/data_migration_test.go
@@ -1,0 +1,122 @@
+package sqlstore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-incident-response/server/playbook"
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOldChecklistToNewChecklist(t *testing.T) {
+	testCases := []struct {
+		name     string
+		old      oldChecklist
+		expected playbook.Checklist
+	}{
+		{
+			"default checklist",
+			oldChecklist{},
+			playbook.Checklist{},
+		},
+		{
+			"one default item",
+			oldChecklist{
+				Items: []oldChecklistItem{{}},
+			},
+			playbook.Checklist{
+				Items: []playbook.ChecklistItem{{}},
+			},
+		},
+		{
+			"complete checklist",
+			oldChecklist{
+				Title: "A checklist",
+				Items: []oldChecklistItem{
+					{
+						Title:       "not checked, no assignee",
+						State:       playbook.ChecklistItemStateOpen,
+						Command:     "/slashcmd",
+						Description: "A detailed item",
+					},
+					{
+						Title:               "checked, no assignee",
+						State:               playbook.ChecklistItemStateClosed,
+						StateModified:       time.Date(2017, 7, 14, 2, 40, 0, 0, time.UTC),
+						StateModifiedPostID: "state post id",
+					},
+					{
+						Title:                  "not checked, assignee",
+						State:                  playbook.ChecklistItemStateOpen,
+						AssigneeID:             "assignee id",
+						AssigneeModified:       time.Date(2020, 9, 13, 12, 26, 40, 0, time.UTC),
+						AssigneeModifiedPostID: "assignee post id",
+					},
+					{
+						Title:                  "checked, assignee",
+						State:                  playbook.ChecklistItemStateClosed,
+						StateModified:          time.Date(2020, 9, 25, 8, 47, 22, 0, time.UTC),
+						StateModifiedPostID:    "state post id",
+						AssigneeID:             "assigneed id",
+						AssigneeModified:       time.Date(2020, 9, 25, 2, 31, 1, 0, time.UTC),
+						AssigneeModifiedPostID: "assignee post id",
+					},
+				},
+			},
+			playbook.Checklist{
+				Title: "A checklist",
+				Items: []playbook.ChecklistItem{
+					{
+						Title:       "not checked, no assignee",
+						State:       playbook.ChecklistItemStateOpen,
+						Command:     "/slashcmd",
+						Description: "A detailed item",
+					},
+					{
+						Title:               "checked, no assignee",
+						State:               playbook.ChecklistItemStateClosed,
+						StateModified:       1500000000000,
+						StateModifiedPostID: "state post id",
+					},
+					{
+						Title:                  "not checked, assignee",
+						State:                  playbook.ChecklistItemStateOpen,
+						AssigneeID:             "assignee id",
+						AssigneeModified:       1600000000000,
+						AssigneeModifiedPostID: "assignee post id",
+					},
+					{
+						Title:                  "checked, assignee",
+						State:                  playbook.ChecklistItemStateClosed,
+						StateModified:          1601023642000,
+						StateModifiedPostID:    "state post id",
+						AssigneeID:             "assigneed id",
+						AssigneeModified:       1601001061000,
+						AssigneeModifiedPostID: "assignee post id",
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := oldChecklistToNewChecklist(testCase.old)
+
+			require.True(t, model.IsValidId(actual.ID))
+			require.Equal(t, testCase.expected.Title, actual.Title)
+			require.Equal(t, len(testCase.expected.Items), len(actual.Items))
+			for i, actualItem := range actual.Items {
+				expectedItem := testCase.expected.Items[i]
+
+				// The IDs are generated, we can only check that it is valid and
+				// assign it to the expected value for the comparison to work
+				require.True(t, model.IsValidId(actualItem.ID))
+				expectedItem.ID = actualItem.ID
+
+				require.Equal(t, expectedItem, actualItem)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Summary

Before #274, the `ChecklistItem` structs had two `time.Time` fields: `StateModified` and `AssigneeModified`. Now, those timestamps are stored as `int64` fields that contain the number of milliseconds since the unix epoch.

When doing the data migration, we used [`model.GetMillisForTime`](https://github.com/mattermost/mattermost-server/blob/30bd506e7676033bdfb632f566e538d6cd3d8be0/model/utils.go#L179-L182) directly on the timestamps, but we never checked whether they had a zero value. It turns out that converting the zero value of a `time.Time` using that function returns a negative number. Specifically, the value `-6795364578871`. This value is then stored in all items that were never checked (in which case, `StateModified` has this value) or that never got an assignee (in which case, `AssigneeModified` has this value). Parsing that value in the client with `moment` returns an invalid date, but `moment('-6795364578871').isSameOrAfter('2020-01-01')` (a common check in the webapp) is always `false`, which is nice.


This PR fixes the data migration, just making sure that the zero value is never converted to milliseconds using the function, using an `int64` 0 instead. I refactored the loop in `checklistsToJSON` into a new function `oldChecklistToNewChecklist`, where the fix is applied. I added a test to make sure that this new function behaves as expected.

This bug is present only in the servers that have already migrated to the SQL store (probably, only ours). However, we need to make sure that we're not using these buggy timestamps anywhere. In the server code, we only use `StateModified` and `AssigneeModified` to change its value, never to read it (except for when we marshal it into JSON and send it to the client). In the client code, `assignee_modified` is never used (interesting) and we use the `state_modified` field in these cases:
- in [components/checklist_item.tsx](https://github.com/mattermost/mattermost-plugin-incident-response/blob/2049861337258fc77a9aaa42233653a389342d10/webapp/src/components/checklist_item.tsx#L203): inside the `ChecklistItemDetails` component, used to render the timestamp of checked items; it is guarded by a check that makes sure that the timestamp is after 2020-01-01, so we're safe.
- in [components/backstage/incidents/incident-detials/checklist_timeline.tsx](https://github.com/mattermost/mattermost-plugin-incident-response/blob/ee86e9eaede65f5da5acc13cebe17c3989717d11/webapp/src/components/backstage/incidents/incident_details/checklist_timeline.tsx#L240): inside the `initData` function; only parsed timestamps that are after 2020-01-01 are handled, so we're safe there.
- in [components/backstage/incidents/incident-detials/checklist_timeline.tsx](https://github.com/mattermost/mattermost-plugin-incident-response/blob/ee86e9eaede65f5da5acc13cebe17c3989717d11/webapp/src/components/backstage/incidents/incident_details/checklist_timeline.tsx#L177): inside the graph callback `tooltipLabel`, it is directly parsed with moment. This is the only one that is never checked, but I *believe* (I'm not 100% sure) that this label is only used for checked items, in which case the timestamp will be correct. The worst-case scenario here is that the graph with the details contain a label with 'Invalid date', in which case we'll get a bug report immediately (however, I have checked and saw no such timestamps in the graph).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29021
