### PR TITLE
 More closely match server golangci configuration, removing some flaky linters.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,11 +12,8 @@ run:
 linters:
   disable-all: true
   enable:
-    - bodyclose
     - deadcode
     - errcheck
-    - goconst
-    - gocritic
     - gofmt
     - goimports
     - golint
@@ -24,44 +21,21 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - misspell
     - scopelint
     - staticcheck
     - structcheck
-    - stylecheck
-    - typecheck
-    - unconvert
     - unconvert
     - unused
-    - unparam
     - varcheck
-    - whitespace
 
 linters-settings:
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - hugeParam
-      - rangeValCopy
   gofmt:
     simplify: true
-  goimports:
-    local-prefixes: github.com/mattermost/mattermost-plugin-api
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: true
     enable-all: true
-  misspell:
-    locale: US
+  goimports:
+    local-prefixes: github.com/mattermost/mattermost-plugin-api
 
 issues:
   exclude-rules:


### PR DESCRIPTION
#### Summary
More closely matches server golang-ci config
Removes some flaky inters affecting PRs: https://github.com/mattermost/mattermost-plugin-incident-response/pull/290

