### PR TITLE
Fix link in slash commands help text

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -24,7 +24,7 @@ const helpText = "###### Mattermost Incident Response Plugin - Slash Command Hel
 	"* `/incident check [checklist #] [item #]` - check/uncheck the checklist item. \n" +
 	"* `/incident announce ~[channels]` - Announce the currrent incident in other channels. \n" +
 	"\n" +
-	"Learn more [in our documentation](https://mattermost.com/pl/default-incident-response-app-documentation). \n" +
+	"Learn more [in our documentation](https://docs.mattermost.com/administration/devops-command-center.html). \n" +
 	""
 
 const confirmPrompt = "CONFIRM"


### PR DESCRIPTION
#### Summary
This PR fixes a dead link in the help text from the slash commands.

It was linking to https://mattermost.com/pl/default-incident-response-app-documentation as our documentation, but that resolves to a weirdly unstyled frontpage of the docs site. I changed it to what I *think* is the canonical location of the user-facing documentation, https://docs.mattermost.com/administration/devops-command-center.html, but I'm not entirely sure I am right.

#### Ticket Link
--
