### PR TITLE
Add /incident info

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -23,8 +23,9 @@ const helpText = "###### Mattermost Incident Response Plugin - Slash Command Hel
 	"* `/incident start` - Start a new incident. \n" +
 	"* `/incident end` - Close the incident of that channel. \n" +
 	"* `/incident check [checklist #] [item #]` - check/uncheck the checklist item. \n" +
-	"* `/incident announce ~[channels]` - Announce the currrent incident in other channels. \n" +
+	"* `/incident announce ~[channels]` - Announce the current incident in other channels. \n" +
 	"* `/incident list` - List all your incidents. \n" +
+	"* `/incident info` - Show a summary of the current incident. \n" +
 	"\n" +
 	"Learn more [in our documentation](https://mattermost.com/pl/default-incident-response-app-documentation). \n" +
 	""
@@ -45,7 +46,7 @@ func getCommand() *model.Command {
 		DisplayName:      "Incident",
 		Description:      "Incident Response Plugin",
 		AutoComplete:     true,
-		AutoCompleteDesc: "Available commands: start, end, restart, check, announce, list",
+		AutoCompleteDesc: "Available commands: start, end, restart, check, announce, list, info",
 		AutoCompleteHint: "[command]",
 		AutocompleteData: getAutocompleteData(),
 	}
@@ -81,6 +82,9 @@ func getAutocompleteData() *model.AutocompleteData {
 
 	list := model.NewAutocompleteData("list", "", "Lists all your incidents")
 	slashIncident.AddCommand(list)
+
+	info := model.NewAutocompleteData("info", "", "Shows a summary of the current incident")
+	slashIncident.AddCommand(info)
 
 	return slashIncident
 }
@@ -309,7 +313,77 @@ func (r *Runner) actionList() {
 			"attachments": attachments,
 		},
 	}
+	r.poster.EphemeralPost(r.args.UserId, r.args.ChannelId, post)
+}
 
+func (r *Runner) actionInfo() {
+	incidentID, err := r.incidentService.GetIncidentIDForChannel(r.args.ChannelId)
+	if err != nil {
+		if errors.Is(err, incident.ErrNotFound) {
+			r.postCommandResponse("You can only show the details of an incident from within the incident's channel.")
+			return
+		}
+		r.warnUserAndLogErrorf("Error retrieving incident: %v", err)
+		return
+	}
+
+	session, err := r.pluginAPI.Session.Get(r.context.SessionId)
+	if err != nil {
+		r.warnUserAndLogErrorf("Error retrieving session: %v", err)
+		return
+	}
+
+	if !session.IsMobileApp() {
+		// The RHS was opened by the webapp, so inform the user
+		r.postCommandResponse("See the incident's information on the RHS.")
+		return
+	}
+
+	theIncident, err := r.incidentService.GetIncident(incidentID)
+	if err != nil {
+		r.warnUserAndLogErrorf("Error retrieving incident: %v", err)
+		return
+	}
+
+	commander, err := r.pluginAPI.User.Get(theIncident.CommanderUserID)
+	if err != nil {
+		r.warnUserAndLogErrorf("Error retrieving commander user: %v", err)
+		return
+	}
+
+	if theIncident.ActiveStage >= len(theIncident.Checklists) {
+		r.warnUserAndLogErrorf("Error retrieving current checklist: active stage is %d and the incident has %d checklists", theIncident.ActiveStage, len(theIncident.Checklists))
+		return
+	}
+
+	activeChecklist := theIncident.Checklists[theIncident.ActiveStage]
+
+	tasks := ""
+	for _, item := range activeChecklist.Items {
+		icon := ":white_large_square: "
+		timestamp := ""
+		if item.State == playbook.ChecklistItemStateClosed {
+			icon = ":white_check_mark: "
+			timestamp = " (" + getTimeForMillis(item.StateModified).Format("15:04 PM") + ")"
+		}
+
+		tasks += icon + item.Title + timestamp + "\n"
+	}
+	attachment := &model.SlackAttachment{
+		Fields: []*model.SlackAttachmentField{
+			{Title: "Incident Name:", Value: fmt.Sprintf("**%s**", strings.Trim(theIncident.Name, " "))},
+			{Title: "Duration:", Value: durationString(getTimeForMillis(theIncident.CreateAt), time.Now())},
+			{Title: "Commander:", Value: fmt.Sprintf("@%s", commander.Username)},
+			{Title: "Stage:", Value: fmt.Sprintf("%s", activeChecklist.Title)},
+			{Title: "Tasks:", Value: tasks},
+		},
+	}
+
+	post := &model.Post{
+		Props: map[string]interface{}{
+			"attachments": []*model.SlackAttachment{attachment},
+		},
+	}
 	r.poster.EphemeralPost(r.args.UserId, r.args.ChannelId, post)
 }
 
@@ -698,6 +772,8 @@ func (r *Runner) Execute() error {
 		r.actionAnnounce(parameters)
 	case "list":
 		r.actionList()
+	case "info":
+		r.actionInfo()
 	case "nuke-db":
 		r.actionNukeDB(parameters)
 	case "st":

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -408,11 +408,10 @@ func (r *Runner) actionList() {
 
 func (r *Runner) actionInfo() {
 	incidentID, err := r.incidentService.GetIncidentIDForChannel(r.args.ChannelId)
-	if err != nil {
-		if errors.Is(err, incident.ErrNotFound) {
-			r.postCommandResponse("You can only show the details of an incident from within the incident's channel.")
-			return
-		}
+	if errors.Is(err, incident.ErrNotFound) {
+		r.postCommandResponse("You can only show the details of an incident from within the incident's channel.")
+		return
+	} else if err != nil {
 		r.warnUserAndLogErrorf("Error retrieving incident: %v", err)
 		return
 	}

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -424,7 +424,7 @@ func (r *Runner) actionInfo() {
 
 	if !session.IsMobileApp() {
 		// The RHS was opened by the webapp, so inform the user
-		r.postCommandResponse("See the incident's information on the RHS.")
+		r.postCommandResponse("Your incident details are already open in the right hand side of the channel.")
 		return
 	}
 

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -463,7 +463,7 @@ func (r *Runner) actionInfo() {
 			{Title: "Incident Name:", Value: fmt.Sprintf("**%s**", strings.Trim(theIncident.Name, " "))},
 			{Title: "Duration:", Value: durationString(getTimeForMillis(theIncident.CreateAt), time.Now())},
 			{Title: "Commander:", Value: fmt.Sprintf("@%s", commander.Username)},
-			{Title: "Stage:", Value: fmt.Sprintf("%s", activeChecklist.Title)},
+			{Title: "Stage:", Value: activeChecklist.Title},
 			{Title: "Tasks:", Value: tasks},
 		},
 	}

--- a/webapp/src/slash_command.ts
+++ b/webapp/src/slash_command.ts
@@ -1,8 +1,10 @@
 import {Store} from 'redux';
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {generateId} from 'mattermost-redux/utils/helpers';
 
-import {setClientId} from 'src/actions';
+import {toggleRHS, setClientId} from 'src/actions';
+import {isIncidentChannel, isIncidentRHSOpen} from 'src/selectors';
 
 export function makeSlashCommandHook(store: Store<GlobalState>) {
     return (message: string, args = {}) => {
@@ -16,6 +18,17 @@ export function makeSlashCommandHook(store: Store<GlobalState>) {
             store.dispatch(setClientId(clientId));
 
             messageTrimmed = `/incident start ${clientId}`;
+
+            return Promise.resolve({message: messageTrimmed, args});
+        }
+
+        if (messageTrimmed && messageTrimmed.startsWith('/incident info')) {
+            const state = store.getState();
+            const currentChannel = getCurrentChannel(state);
+
+            if (isIncidentChannel(state, currentChannel.id) && !isIncidentRHSOpen(state)) {
+                store.dispatch(toggleRHS());
+            }
 
             return Promise.resolve({message: messageTrimmed, args});
         }

--- a/webapp/src/slash_command.ts
+++ b/webapp/src/slash_command.ts
@@ -27,6 +27,7 @@ export function makeSlashCommandHook(store: Store<GlobalState>) {
             const currentChannel = getCurrentChannel(state);
 
             if (isIncidentChannel(state, currentChannel.id) && !isIncidentRHSOpen(state)) {
+                //@ts-ignore thunk
                 store.dispatch(toggleRHS());
 
                 return Promise.resolve({});

--- a/webapp/src/slash_command.ts
+++ b/webapp/src/slash_command.ts
@@ -28,6 +28,8 @@ export function makeSlashCommandHook(store: Store<GlobalState>) {
 
             if (isIncidentChannel(state, currentChannel.id) && !isIncidentRHSOpen(state)) {
                 store.dispatch(toggleRHS());
+
+                return Promise.resolve({});
             }
 
             return Promise.resolve({message: messageTrimmed, args});


### PR DESCRIPTION
#### Summary

Unsurprisingly, this adds an `/incident info` slash command. I do have an E2E test, but it is based on the changes introduced on #293; as I want these changes to be merged before deploying to community tomorrow, I'm opening this PR without the test. I'll open a new one with the test tomorrow, when the commander slash command is merged.

- If not on an incident channel, it shows an ephemeral message `You can only show the details of an incident from within the incident's channel.`
- If on an incident channel:
  - If command executed from webapp, it just opens the RHS. If it was already open, it shows an ephemeral message `Your incident details are already open in the right hand side of the channel.`
  - If command executed from mobile, it shows the following, non-interactive, info:

![image](https://user-images.githubusercontent.com/3924815/94713588-4df0f680-034b-11eb-89bd-d75b252c167e.png)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

