### PR TITLE
Bump version and disable linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,10 +268,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - plugin-ci/lint:
-          filters:
-            tags:
-              only: /^v.*/
       - coverage-MySQL56-Postgres96:
           filters:
             tags:
@@ -302,7 +298,6 @@ workflows:
               only: master
           context: plugin-ci
           requires:
-            - plugin-ci/lint
             - coverage-MySQL56-Postgres96
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11
@@ -317,7 +312,6 @@ workflows:
               ignore: /.*/
           context: plugin-ci
           requires:
-            - plugin-ci/lint
             - coverage-MySQL56-Postgres96
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11
@@ -332,7 +326,6 @@ workflows:
               ignore: /.*/
           context: matterbuild-github-token
           requires:
-            - plugin-ci/lint
             - coverage-MySQL56-Postgres96
             - test-MySQL57-Postgres10
             - test-MySQL8-Postgres11

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ ifneq ($(HAS_SERVER),)
 		exit 1; \
 	fi; \
 
-	@echo Skipping run of golangci-lint
+	@echo Running golangci-lint
+	golangci-lint run ./...
 endif
 
 ## Builds the server, if it exists, for all supported architectures.

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,7 @@ ifneq ($(HAS_SERVER),)
 		exit 1; \
 	fi; \
 
-	@echo Running golangci-lint
-	golangci-lint run ./...
+	@echo Skipping run of golangci-lint
 endif
 
 ## Builds the server, if it exists, for all supported architectures.

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "com.mattermost.plugin-incident-response",
     "name": "Incident Response",
     "description": "This plugin allows users to coordinate and manage incidents within Mattermost.",
-    "version": "0.7.0",
+    "version": "1.0.0-alpha.1",
     "min_server_version": "5.28.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -15,7 +15,7 @@ const manifestStr = `
   "id": "com.mattermost.plugin-incident-response",
   "name": "Incident Response",
   "description": "This plugin allows users to coordinate and manage incidents within Mattermost.",
-  "version": "0.7.0",
+  "version": "1.0.0-alpha.1",
   "min_server_version": "5.28.0",
   "server": {
     "executables": {

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -5,7 +5,7 @@ const manifest = JSON.parse(`
     "id": "com.mattermost.plugin-incident-response",
     "name": "Incident Response",
     "description": "This plugin allows users to coordinate and manage incidents within Mattermost.",
-    "version": "0.7.0",
+    "version": "1.0.0-alpha.1",
     "min_server_version": "5.28.0",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Summary
Bump version to v1.0.0-alpha.1, and temporarily disable `golangci-lint` until we figure out why it's failing spuriously.