### PR TITLE
Add E2E test for /incident info

### DIFF
--- a/tests-e2e/cypress/integration/frontstage/slash_command_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/slash_command_spec.js
@@ -207,4 +207,48 @@ describe('slash command', () => {
             cy.verifyEphemeralMessage('/incident commander expects at most one argument.');
         });
     });
+
+    describe('/incident info', () => {
+        it('should show an error when not in an incident channel', () => {
+            // # Navigate to a non-incident channel.
+            cy.visit('/ad-1/channels/town-square');
+
+            // # Run a slash command to show the incident's info.
+            cy.executeSlashCommand('/incident info');
+
+            // * Verify the expected error message.
+            cy.verifyEphemeralMessage('You can only show the details of an incident from within the incident\'s channel.');
+        });
+
+        it('should open the RHS when it is not open', () => {
+            // # Navigate directly to the application and the incident channel.
+            cy.visit('/ad-1/channels/' + incidentChannelName);
+
+            // # Close the RHS, which is opened by default when navigating to an incident channel.
+            cy.get('#searchResultsCloseButton').click();
+
+            // * Verify that the RHS is indeed closed.
+            cy.get('#rhsContainer').should('not.be.visible');
+
+            // # Run a slash command to show the incident's info.
+            cy.executeSlashCommand('/incident info');
+
+            // * Verify that the RHS is now open.
+            cy.get('#rhsContainer').should('be.visible');
+        });
+
+        it('should show an ephemeral post when the RHS is already open', () => {
+            // # Navigate directly to the application and the incident channel.
+            cy.visit('/ad-1/channels/' + incidentChannelName);
+
+            // * Verify that the RHS is open.
+            cy.get('#rhsContainer').should('be.visible');
+
+            // # Run a slash command to show the incident's info.
+            cy.executeSlashCommand('/incident info');
+
+            // * Verify the expected error message.
+            cy.verifyEphemeralMessage('Your incident details are already open in the right hand side of the channel.');
+        });
+    })
 });


### PR DESCRIPTION
#### Summary
This PR adds the E2E test for `/incident info` promised in #306.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28286