### PR TITLE
MM-28296: improved slash command autocomplete

### DIFF
--- a/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
@@ -12,7 +12,7 @@ describe('backstage playbook details', () => {
         cy.apiLogin('user-1');
     });
 
-    xit('redirects to not found error if the playbook is unknown', () => {
+    it('redirects to not found error if the playbook is unknown', () => {
         // # Visit the URL of a non-existing playbook
         cy.visit('/ad-1/com.mattermost.plugin-incident-response/playbooks/an_unknown_id');
 

--- a/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
@@ -12,11 +12,76 @@ describe('backstage playbook details', () => {
         cy.apiLogin('user-1');
     });
 
-    it('redirects to not found error if the playbook is unknown', () => {
+    xit('redirects to not found error if the playbook is unknown', () => {
         // # Visit the URL of a non-existing playbook
         cy.visit('/ad-1/com.mattermost.plugin-incident-response/playbooks/an_unknown_id');
 
         // * Verify that the user has been redirected to the playbooks not found error page
         cy.url().should('include', '/ad-1/com.mattermost.plugin-incident-response/error?type=playbooks');
+    });
+
+    describe('slash command', () => {
+        it('autocompletes after clicking Add a Slash Command', () => {
+            // # Visit the playbook backstage
+            cy.visit('/ad-1/com.mattermost.plugin-incident-response/playbooks');
+
+            // # Start a blank playbook
+            cy.get('#root').findByText('Blank Playbook').click();
+
+            // # Add a slash command to a step
+            cy.get('#root').findByText('Add a Slash Command').click();
+
+            // * Verify the slash command input field now has focus
+            cy.get('#root').findByPlaceholderText('Slash Command').should('have.focus');
+
+            // * Verify the slash command input field is pre-populated with a leading slash
+            cy.get('#root').findByPlaceholderText('Slash Command').should('have.value', '/');
+
+            // * Verify the autocomplete prompt is open
+            cy.get('#suggestionList').should('be.visible');
+        });
+
+        it('removes the input prompt when blurring with an empty slash command', () => {
+            // # Visit the playbook backstage
+            cy.visit('/ad-1/com.mattermost.plugin-incident-response/playbooks');
+
+            // # Start a blank playbook
+            cy.get('#root').findByText('Blank Playbook').click();
+
+            // # Add a slash command to a step
+            cy.get('#root').findByText('Add a Slash Command').click();
+
+            // * Verify only the leading slash is in the input field.
+            cy.get('#root').findByPlaceholderText('Slash Command').should('have.value', '/');
+
+            // # Backspace even the slash in the input.
+            cy.get('#root').findByPlaceholderText('Slash Command').type('{backspace}');
+
+            // # Blur the slash command input field
+            cy.get('#root').findByPlaceholderText('Slash Command').blur();
+
+            // # Verify the Add a Slash Command button returns
+            cy.get('#root').findByText('Add a Slash Command').should('be.visible');
+        });
+
+        it('removes the input prompt when blurring with an invalid slash command', () => {
+            // # Visit the playbook backstage
+            cy.visit('/ad-1/com.mattermost.plugin-incident-response/playbooks');
+
+            // # Start a blank playbook
+            cy.get('#root').findByText('Blank Playbook').click();
+
+            // # Add a slash command to a step
+            cy.get('#root').findByText('Add a Slash Command').click();
+
+            // * Verify only the leading slash is in the input field.
+            cy.get('#root').findByPlaceholderText('Slash Command').should('have.value', '/');
+
+            // # Blur the slash command without having typed anything more
+            cy.get('#root').findByPlaceholderText('Slash Command').blur();
+
+            // * Verify the Add a Slash Command button returns
+            cy.get('#root').findByText('Add a Slash Command').should('be.visible');
+        });
     });
 });

--- a/webapp/src/components/backstage/step_edit.tsx
+++ b/webapp/src/components/backstage/step_edit.tsx
@@ -263,11 +263,13 @@ const StepCommand: FC<StepCommandProps> = (props: StepCommandProps) => {
 
     const save = () => {
         // Discard invalid slash commands.
-        if (command.trim() === '/') {
+        if (command.trim() === '/' || command.trim() === '') {
             setCommand('');
+            props.setCommand('');
+            setCommandOpen(false);
+        } else {
+            props.setCommand(command);
         }
-
-        props.setCommand(command);
     };
 
     let slashCommandBox = (


### PR DESCRIPTION
#### Summary
When the slash command prompt in the playbook details backstage is blurred with an empty or only `/` value, just revert back to `Add a Slash Command` as though nothing was entered. This  makes it easy to click back in and trigger the autocomplete prompt right away.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-28037