### PR TITLE
MM-29158: fix custom components in react select

### DIFF
--- a/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
+++ b/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
@@ -35,6 +35,20 @@ import {BACKSTAGE_LIST_PER_PAGE} from 'src/constants';
 
 const debounceDelay = 300; // in milliseconds
 
+const ControlComponent = (ownProps: ControlProps<any>) => (
+    <div>
+        <components.Control {...ownProps}/>
+        {ownProps.selectProps.showCustomReset && (
+            <a
+                className='IncidentFilter-reset'
+                onClick={ownProps.selectProps.onCustomReset}
+            >
+                {'Reset to all commanders'}
+            </a>
+        )}
+    </div>
+);
+
 const BackstageIncidentList: FC = () => {
     const [incidents, setIncidents] = useState<Incident[]>([]);
     const [totalCount, setTotalCount] = useState(0);
@@ -110,32 +124,17 @@ const BackstageIncidentList: FC = () => {
     }
 
     const [profileSelectorToggle, setProfileSelectorToggle] = useState(false);
-    const ControlComponent = (ownProps: ControlProps<any>) => {
-        const resetLink = fetchParams.commander_user_id && (
-            <a
-                className='IncidentFilter-reset'
-                onClick={() => {
-                    setCommanderId();
-                    setProfileSelectorToggle(!profileSelectorToggle);
-                }}
-            >
-                {'Reset to all commanders'}
-            </a>
-        );
-
-        return (
-            <div>
-                <components.Control {...ownProps}/>
-                {resetLink}
-            </div>
-        );
-    };
 
     const isFiltering = (
         fetchParams.search_term ||
         fetchParams.commander_user_id ||
         (fetchParams.status && fetchParams.status !== 'all')
     );
+
+    const resetCommander = () => {
+        setCommanderId();
+        setProfileSelectorToggle(!profileSelectorToggle);
+    };
 
     const listComponent = (
         <div className='IncidentList container-medium'>
@@ -165,6 +164,10 @@ const BackstageIncidentList: FC = () => {
                         enableEdit={true}
                         isClearable={true}
                         customControl={ControlComponent}
+                        customControlProps={{
+                            showCustomReset: Boolean(fetchParams.commander_user_id),
+                            onCustomReset: resetCommander,
+                        }}
                         controlledOpenToggle={profileSelectorToggle}
                         getUsers={fetchCommanders}
                         onSelectedChange={setCommanderId}

--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -144,6 +144,20 @@ const StepDescription = (props: StepDescriptionProps) : React.ReactElement<StepD
     );
 };
 
+const ControlComponent = (ownProps: ControlProps<any>) => (
+    <div>
+        <components.Control {...ownProps}/>
+        {ownProps.selectProps.showCustomReset && (
+            <a
+                className='IncidentFilter-reset'
+                onClick={ownProps.selectProps.onCustomReset}
+            >
+                {'No Assignee'}
+            </a>
+        )}
+    </div>
+);
+
 export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.ReactElement => {
     const channelNamesMap = useSelector<GlobalState, ChannelNamesMap>(getChannelsNameMapInCurrentTeam);
     const team = useSelector<GlobalState, Team>(getCurrentTeam);
@@ -186,29 +200,14 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
 
     const [profileSelectorToggle, setProfileSelectorToggle] = useState(false);
     const assignee_id = props.checklistItem.assignee_id; // to make typescript happy
-    const ControlComponent = (ownProps: ControlProps<any>) => {
-        const resetLink = assignee_id && (
-            <a
-                className='IncidentFilter-reset'
-                onClick={() => {
-                    onAssigneeChange();
-                    setProfileSelectorToggle(!profileSelectorToggle);
-                }}
-            >
-                {'No Assignee'}
-            </a>
-        );
-
-        return (
-            <div>
-                <components.Control {...ownProps}/>
-                {resetLink}
-            </div>
-        );
-    };
 
     let timestamp = '';
     const title = props.checklistItem.title;
+
+    const resetAssignee = () => {
+        onAssigneeChange();
+        setProfileSelectorToggle(!profileSelectorToggle);
+    };
 
     if (props.checklistItem.state === ChecklistItemState.Closed && props.checklistItem.state_modified) {
         const stateModified = moment(props.checklistItem.state_modified);
@@ -296,6 +295,10 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
                     onSelectedChange={onAssigneeChange}
                     selfIsFirstOption={true}
                     customControl={ControlComponent}
+                    customControlProps={{
+                        showCustomReset: Boolean(assignee_id),
+                        onCustomReset: resetAssignee,
+                    }}
                     controlledOpenToggle={profileSelectorToggle}
                 />
             </div>

--- a/webapp/src/components/profile/profile_selector.tsx
+++ b/webapp/src/components/profile/profile_selector.tsx
@@ -38,6 +38,7 @@ interface Props {
     selfIsFirstOption?: boolean;
     getUsers: () => Promise<UserProfile[]>;
     onSelectedChange: (userId?: string) => void;
+    customControlProps?: any;
 }
 
 export default function ProfileSelector(props: Props) {
@@ -195,6 +196,7 @@ export default function ProfileSelector(props: Props) {
                 onChange={(option, action) => onSelectedChange(option as Option, action as ActionObj)}
                 classNamePrefix='incident-user-select'
                 className='incident-user-select'
+                {...props.customControlProps}
             />
         </Dropdown>
     );

--- a/webapp/src/components/profile/profile_selector.tsx
+++ b/webapp/src/components/profile/profile_selector.tsx
@@ -16,7 +16,7 @@ import ProfileButton from 'src/components/profile/profile_button';
 
 interface Option {
     value: string;
-    label: JSX.Element;
+    label: JSX.Element|string;
     userId: string;
 }
 
@@ -167,12 +167,7 @@ export default function ProfileSelector(props: Props) {
         );
     }
 
-    // The following is awkward, but makes TS happy.
-    const baseComponents = {DropdownIndicator: null, IndicatorSeparator: null};
-    const components = props.customControl ? {
-        ...baseComponents,
-        Control: props.customControl,
-    } : baseComponents;
+    const components = props.customControl ? {Control: props.customControl} : {};
 
     return (
         <Dropdown


### PR DESCRIPTION

#### Summary
Fix an issue with the `ProfileSelector` being given a `CustomComponent` that is redefined on every render. This breaks the internal logic of react-select, forcing it to render new DOM elements instead of reusing them, and ultimately losing focus. On an active site like community-daily, the re-renders almost most the component unusable.

The fix here was applied both to the backstage and the incident RHS for assignees, making it technically the requisite follow-up to https://github.com/mattermost/mattermost-plugin-incident-response/pull/260. I'm still not sure why the webapp insists on re-rendering practically everything so often.

While in here, I removed one thing tsc no longer complained about, and fixed another.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29158