### PR TITLE
MM-26181: deprecate /end-dialog endpoint

### DIFF
--- a/server/api/api.yaml
+++ b/server/api/api.yaml
@@ -137,23 +137,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /incidents/end-dialog:
-    post:
-      summary: Internal - Ends an incident from dialog
-      operationId: incidentEndDialog
-      security:
-        - BearerAuth: []
-      tags:
-        - Internal-Incidents
-      responses:
-        200:
-          description: Null response
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
 
   /incidents/commanders:
     get:

--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -45,7 +45,6 @@ func NewIncidentHandler(router *mux.Router, incidentService incident.Service, pl
 	incidentsRouter.HandleFunc("", handler.createIncidentFromPost).Methods(http.MethodPost)
 
 	incidentsRouter.HandleFunc("/dialog", handler.createIncidentFromDialog).Methods(http.MethodPost)
-	incidentsRouter.HandleFunc("/end-dialog", handler.endIncidentFromDialog).Methods(http.MethodPost)
 	incidentsRouter.HandleFunc("/commanders", handler.getCommanders).Methods(http.MethodGet)
 	incidentsRouter.HandleFunc("/channels", handler.getChannels).Methods(http.MethodGet)
 	incidentsRouter.HandleFunc("/checklist-autocomplete", handler.getChecklistAutocomplete).Methods(http.MethodGet)
@@ -57,7 +56,7 @@ func NewIncidentHandler(router *mux.Router, incidentService incident.Service, pl
 	incidentRouterAuthorized := incidentRouter.PathPrefix("").Subrouter()
 	incidentRouterAuthorized.Use(handler.checkEditPermissions)
 	incidentRouterAuthorized.HandleFunc("", handler.updateIncident).Methods(http.MethodPatch)
-	incidentRouterAuthorized.HandleFunc("/end", handler.endIncident).Methods(http.MethodPut)
+	incidentRouterAuthorized.HandleFunc("/end", handler.endIncident).Methods(http.MethodPut, http.MethodPost)
 	incidentRouterAuthorized.HandleFunc("/restart", handler.restartIncident).Methods(http.MethodPut)
 	incidentRouterAuthorized.HandleFunc("/commander", handler.changeCommander).Methods(http.MethodPost)
 
@@ -447,11 +446,15 @@ func (h *IncidentHandler) getIncidentByChannel(w http.ResponseWriter, r *http.Re
 }
 
 // endIncident handles the /incidents/{id}/end api endpoint.
+//
+// In addition to being reachable directly via the REST API, the POST version of this endpoint is
+// also used as the target of the interactive dialog spawned by `/incident dialog`.
 func (h *IncidentHandler) endIncident(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
+	incidentID := vars["id"]
 	userID := r.Header.Get("Mattermost-User-ID")
 
-	err := h.incidentService.EndIncident(vars["id"], userID)
+	err := h.incidentService.EndIncident(incidentID, userID)
 	if err != nil {
 		HandleError(w, err)
 		return
@@ -469,25 +472,6 @@ func (h *IncidentHandler) restartIncident(w http.ResponseWriter, r *http.Request
 	err := h.incidentService.RestartIncident(vars["id"], userID)
 	if err != nil {
 		HandleError(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
-}
-
-// endIncidentFromDialog handles the interactive dialog submission when a user confirms they
-// want to end an incident.
-func (h *IncidentHandler) endIncidentFromDialog(w http.ResponseWriter, r *http.Request) {
-	request := model.SubmitDialogRequestFromJson(r.Body)
-	if request == nil {
-		HandleError(w, errors.New("failed to decode SubmitDialogRequest"))
-		return
-	}
-
-	err := h.incidentService.EndIncident(request.State, request.UserId)
-	if err != nil {
-		HandleError(w, errors.Wrapf(err, "failed to end incident"))
 		return
 	}
 

--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -1309,3 +1309,104 @@ func TestChangeActiveStage(t *testing.T) {
 		})
 	}
 }
+
+func TestEndIncident(t *testing.T) {
+	var mockCtrl *gomock.Controller
+	var handler *Handler
+	var poster *mock_poster.MockPoster
+	var logger *mock_poster.MockLogger
+	var playbookService *mock_playbook.MockService
+	var incidentService *mock_incident.MockService
+	var pluginAPI *plugintest.API
+	var client *pluginapi.Client
+
+	reset := func() {
+		mockCtrl = gomock.NewController(t)
+		handler = NewHandler()
+		poster = mock_poster.NewMockPoster(mockCtrl)
+		logger = mock_poster.NewMockLogger(mockCtrl)
+		playbookService = mock_playbook.NewMockService(mockCtrl)
+		incidentService = mock_incident.NewMockService(mockCtrl)
+		pluginAPI = &plugintest.API{}
+		client = pluginapi.NewClient(pluginAPI)
+		NewIncidentHandler(handler.APIRouter, incidentService, playbookService, client, poster, logger)
+	}
+
+	type authorizationFunc func(userID string, req *http.Request, incdnt incident.Incident, pluginAPI *plugintest.API, incidentService mock_incident.MockService)
+
+	unauthorized := func(userID string, req *http.Request, incdnt incident.Incident, pluginAPI *plugintest.API, incidentService mock_incident.MockService) {
+		req.Header.Add("Mattermost-User-ID", userID)
+		pluginAPI.On("HasPermissionTo", userID, model.PERMISSION_MANAGE_SYSTEM).Return(false)
+		incidentService.EXPECT().GetIncident(incdnt.ID).Return(&incdnt, nil).AnyTimes()
+		pluginAPI.On("HasPermissionToChannel", userID, incdnt.ChannelID, model.PERMISSION_READ_CHANNEL).
+			Return(false)
+	}
+
+	authorizedAsSystemAdmin := func(userID string, req *http.Request, incdnt incident.Incident, pluginAPI *plugintest.API, incidentService mock_incident.MockService) {
+		req.Header.Add("Mattermost-User-ID", userID)
+		pluginAPI.On("HasPermissionTo", userID, model.PERMISSION_MANAGE_SYSTEM).Return(true)
+	}
+
+	authorizedAsUserWithPermissionToIncident := func(userID string, req *http.Request, incdnt incident.Incident, pluginAPI *plugintest.API, incidentService mock_incident.MockService) {
+		req.Header.Add("Mattermost-User-ID", userID)
+		pluginAPI.On("HasPermissionTo", userID, model.PERMISSION_MANAGE_SYSTEM).Return(false)
+		incidentService.EXPECT().GetIncident(incdnt.ID).Return(&incdnt, nil).AnyTimes()
+		pluginAPI.On("HasPermissionToChannel", userID, incdnt.ChannelID, model.PERMISSION_READ_CHANNEL).
+			Return(true)
+	}
+
+	methods := []string{http.MethodPut, http.MethodPost}
+	testCases := []struct {
+		Description        string
+		AuthorizationFunc  authorizationFunc
+		ExpectedStatusCode int
+	}{
+		{"not logged in request", nil, http.StatusUnauthorized},
+		{"unauthorized request", unauthorized, http.StatusForbidden},
+		{"successful request as system admin", authorizedAsSystemAdmin, http.StatusOK},
+		{"successful request", authorizedAsUserWithPermissionToIncident, http.StatusOK},
+		{"failed request", authorizedAsUserWithPermissionToIncident, http.StatusInternalServerError},
+		{"failed request as system admin", authorizedAsSystemAdmin, http.StatusInternalServerError},
+	}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			for _, tc := range testCases {
+				t.Run(tc.Description, func(t *testing.T) {
+					reset()
+
+					userID := model.NewId()
+					incidentID := model.NewId()
+					channelID := model.NewId()
+
+					incdnt := incident.Incident{
+						Header: incident.Header{
+							ID:        incidentID,
+							ChannelID: channelID,
+						},
+					}
+
+					recorder := httptest.NewRecorder()
+					req, err := http.NewRequest(method, "/api/v1/incidents/"+incidentID+"/end", nil)
+					require.NoError(t, err)
+
+					if tc.AuthorizationFunc != nil {
+						tc.AuthorizationFunc(userID, req, incdnt, pluginAPI, *incidentService)
+					}
+
+					switch tc.ExpectedStatusCode {
+					case http.StatusOK:
+						incidentService.EXPECT().EndIncident(incidentID, userID)
+					case http.StatusInternalServerError:
+						incidentService.EXPECT().EndIncident(incidentID, userID).Return(errors.New("fake error"))
+					}
+
+					handler.ServeHTTP(recorder, req, "testpluginid")
+					resp := recorder.Result()
+					defer resp.Body.Close()
+					assert.Equal(t, tc.ExpectedStatusCode, resp.StatusCode)
+				})
+			}
+		})
+	}
+}

--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -248,8 +248,11 @@ func (s *ServiceImpl) OpenEndIncidentDialog(incidentID, triggerID string) error 
 	}
 
 	dialogRequest := model.OpenDialogRequest{
-		URL: fmt.Sprintf("/plugins/%s/api/v1/incidents/end-dialog",
-			s.configService.GetManifest().Id),
+		URL: fmt.Sprintf(
+			"/plugins/%s/api/v1/incidents/%s/end",
+			s.configService.GetManifest().Id,
+			incidentID,
+		),
 		Dialog:    dialog,
 		TriggerId: triggerID,
 	}


### PR DESCRIPTION
#### Summary
Fallback to just supporting POST against `/incidents/<id>/end`. The original ticket here called for creating `/incidents/<id>/end`, but that was effort done earlier for other reasons.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-26181
