### PR TITLE
MM-28941: stage progress bar

### DIFF
--- a/webapp/src/components/rhs/incident_details.tsx
+++ b/webapp/src/components/rhs/incident_details.tsx
@@ -59,6 +59,7 @@ function renderThumbVertical(props: any): JSX.Element {
 interface StageProps {
     stages: Checklist[];
     activeStage: number;
+    isIncidentActive: boolean;
 }
 
 const StageWrapper = styled.div`
@@ -92,7 +93,63 @@ const Stage: FC<StageProps> = (props: StageProps) => {
                     {`(${props.activeStage + 1}/${props.stages.length})`}
                 </StageCounter>
             </StageWrapper>
+            <StageProgressBar {...props}/>
         </div>
+    );
+};
+
+const StageProgressBarElements = styled.div`
+    display: flex;
+    margin-top: 8px;
+`;
+
+interface StageProgressBarElementProps {
+    active: boolean;
+    finished: boolean;
+}
+
+const StageProgressBarElement = styled.div<StageProgressBarElementProps>`
+    height: 8px;
+    width: 100%;
+    margin-right: 3px;
+    background-color: rgba(var(--center-channel-color-rgb), 0.08);
+
+    ${(props) => (props.active && css`
+        background-color: rgba(var(--button-bg-rgb), 0.2);
+    `)}
+
+    ${(props) => (props.finished && css`
+        background-color: var(--button-bg);
+    `)}
+
+
+    &:first-child {
+        border-top-left-radius: 4px;
+        border-bottom-left-radius: 4px;
+    }
+
+    &:last-child {
+        border-top-right-radius: 4px;
+        border-bottom-right-radius: 4px;
+        margin-right: 0;
+    }
+`;
+
+const StageProgressBar: FC<StageProps> = (props: StageProps) => {
+    if (props.stages.length <= 1) {
+        return null;
+    }
+
+    return (
+        <StageProgressBarElements>
+            {props.stages.map((_, index) => (
+                <StageProgressBarElement
+                    key={index}
+                    active={props.activeStage === index}
+                    finished={props.activeStage > index || !props.isIncidentActive}
+                />
+            ))}
+        </StageProgressBarElements>
     );
 };
 
@@ -137,7 +194,6 @@ const StyledButton = styled(BasicButton)<BasicButtonProps>`
         background: var(--button-bg);
         color: var(--button-color);
     `}
-}
 `;
 
 const NextStageButton: FC<NextStageButtonProps> = (props: NextStageButtonProps) => {
@@ -273,6 +329,7 @@ const RHSIncidentDetails: FC<Props> = (props: Props) => {
                     <Stage
                         stages={checklists}
                         activeStage={activeChecklistIdx}
+                        isIncidentActive={props.incident.is_active}
                     />
                     <div
                         className='checklist-inner-container'


### PR DESCRIPTION
#### Summary
One stage:
<img width="376" alt="image" src="https://user-images.githubusercontent.com/1023171/95391694-e3513500-08cd-11eb-8e09-0560f42ee195.png">

Two stages:
<img width="385" alt="image" src="https://user-images.githubusercontent.com/1023171/95391705-e9471600-08cd-11eb-919a-663857d3a224.png">

Three stages, 2nd stage active:
<img width="393" alt="image" src="https://user-images.githubusercontent.com/1023171/95391737-f49a4180-08cd-11eb-90b8-f5c47feb2feb.png">

Ten stages, incident ended, themed:
<img width="382" alt="image" src="https://user-images.githubusercontent.com/1023171/95391789-0aa80200-08ce-11eb-8482-9976d997d310.png">

Many stages, third stage active:
<img width="382" alt="image" src="https://user-images.githubusercontent.com/1023171/95391815-1693c400-08ce-11eb-87f2-156108bbbf64.png">

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28941