### PR TITLE
fix sort by status

### DIFF
--- a/server/incident/filter_options.go
+++ b/server/incident/filter_options.go
@@ -76,6 +76,7 @@ func IsValidSortBy(sortBy string) bool {
 		SortByCommanderUserID,
 		SortByTeamID,
 		SortByEndAt,
+		SortByStatus,
 		SortByIsActive:
 		return true
 	}
@@ -111,6 +112,7 @@ func ValidateOptions(options *HeaderFilterOptions) error {
 	case SortByEndAt:
 		options.Sort = "EndAt"
 	case SortByIsActive:
+	case SortByStatus:
 		options.Sort = "IsActive"
 	default:
 		return errors.New("bad parameter 'sort'")

--- a/server/incident/filter_options.go
+++ b/server/incident/filter_options.go
@@ -76,7 +76,6 @@ func IsValidSortBy(sortBy string) bool {
 		SortByCommanderUserID,
 		SortByTeamID,
 		SortByEndAt,
-		SortByStatus,
 		SortByIsActive:
 		return true
 	}
@@ -112,7 +111,6 @@ func ValidateOptions(options *HeaderFilterOptions) error {
 	case SortByEndAt:
 		options.Sort = "EndAt"
 	case SortByIsActive:
-	case SortByStatus:
 		options.Sort = "IsActive"
 	default:
 		return errors.New("bad parameter 'sort'")

--- a/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
+++ b/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
@@ -108,7 +108,7 @@ const BackstageIncidentList: FC = () => {
 
         // change to a new column; default to descending for time-based columns, ascending otherwise
         let newOrder = 'desc';
-        if (['name', 'status'].indexOf(colName) !== -1) {
+        if (['name', 'is_active'].indexOf(colName) !== -1) {
             newOrder = 'asc';
         }
         setFetchParams({...fetchParams, sort: colName, order: newOrder});
@@ -195,8 +195,8 @@ const BackstageIncidentList: FC = () => {
                             <SortableColHeader
                                 name={'Status'}
                                 order={fetchParams.order ? fetchParams.order : 'desc'}
-                                active={fetchParams.sort ? fetchParams.sort === 'status' : false}
-                                onClick={() => colHeaderClicked('status')}
+                                active={fetchParams.sort ? fetchParams.sort === 'is_active' : false}
+                                onClick={() => colHeaderClicked('is_active')}
                             />
                         </div>
                         <div className='col-sm-2'>


### PR DESCRIPTION
#### Summary
Another quick fix, this one to fix sorting by status by sending up `is_active` as the key instead of the unsupported `status`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29371