### PR TITLE
MM-29286: Change API version to v0

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	apiVersion = "v1"
+	apiVersion = "v0"
 	manifestID = "com.mattermost.plugin-incident-response"
 	userAgent  = "go-client/" + apiVersion
 )

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -26,7 +26,7 @@ func NewHandler() *Handler {
 	handler := &Handler{}
 
 	root := mux.NewRouter()
-	api := root.PathPrefix("/api/v1").Subrouter()
+	api := root.PathPrefix("/api/v0").Subrouter()
 	api.Use(MattermostAuthorizationRequired)
 	api.Handle("{anything:.*}", http.NotFoundHandler())
 	api.NotFoundHandler = http.NotFoundHandler()

--- a/server/api/api.yaml
+++ b/server/api/api.yaml
@@ -7,7 +7,7 @@ info:
     url: https://mattermost.com/
     email: support@mattermost.com
 servers:
-  - url: http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1
+  - url: http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0
 paths:
   /incidents:
     get:
@@ -71,7 +71,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents' \
+            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -102,7 +102,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents' \
+            curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -H 'Content-Type: application/json'\
             -d '{"name": "ExampleIncident", "commander_user_id": "guo3e74njbbdxcpa6p43q974ar", "team_id": "ni8duypfe7bamprxqeffd563gy"}'
@@ -156,7 +156,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/commanders?team_id=ni8duypfe7bamprxqeffd563gy' \
+            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/commanders?team_id=ni8duypfe7bamprxqeffd563gy' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -193,7 +193,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/channels?team_id=ni8duypfe7bamprxqeffd563gy' \
+            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/channels?team_id=ni8duypfe7bamprxqeffd563gy' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -229,7 +229,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/channel/bdjeidoautgdjxqtgrmm78cg8a' \
+            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/channel/bdjeidoautgdjxqtgrmm78cg8a' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -263,7 +263,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/1igmynxs77ywmcbwbsujzktter' \
+            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/1igmynxs77ywmcbwbsujzktter' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -297,7 +297,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/1igmynxs77ywmcbwbsujzktter/details' \
+            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/1igmynxs77ywmcbwbsujzktter/details' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -331,7 +331,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/1igmynxs77ywmcbwbsujzktter/end' \
+            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/1igmynxs77ywmcbwbsujzktter/end' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -377,7 +377,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/1igmynxs77ywmcbwbsujzktter/commander' \
+            curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/1igmynxs77ywmcbwbsujzktter/commander' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"commander_id": "guo3e74njbbdxcpa6p43q974ar"}'
       responses:
@@ -424,7 +424,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/add' \
+            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/add' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"title": "Title"}'
       responses:
@@ -481,7 +481,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/reorder' \
+            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/reorder' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"item_num": 0, "new_location": 2}'
       responses:
@@ -540,7 +540,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/item/0' \
+            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/item/0' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"title": "new_title"}'
       responses:
@@ -585,7 +585,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X DELETE 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/item/0' \
+            curl -X DELETE 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/item/0' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -631,7 +631,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/item/0/check' \
+            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/item/0/check' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -677,7 +677,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/item/0/uncheck' \
+            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/incidents/x1938wijrbgkbfqh56r3m1owzh/checklists/0/item/0/uncheck' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -740,7 +740,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/playbooks?team_id=ni8duypfe7bamprxqeffd563gy&sort=title&direction=asc' \
+            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/playbooks?team_id=ni8duypfe7bamprxqeffd563gy&sort=title&direction=asc' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -771,7 +771,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/playbooks?team_id=ni8duypfe7bamprxqeffd563gy' \
+            curl -X POST 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/playbooks?team_id=ni8duypfe7bamprxqeffd563gy' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"title": "Playbook","team_id": "ni8duypfe7bamprxqeffd563gy","create_public_incident": true,"checklists": [{"title": "Title","items": [{"title": "Title"}]}]}'
       responses:
@@ -813,7 +813,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/playbooks/qp96egozepn58mg93wein1e8pe' \
+            curl -X GET 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/playbooks/qp96egozepn58mg93wein1e8pe' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:
@@ -852,7 +852,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/playbooks/qp96egozepn58mg93wein1e8pe' \
+            curl -X PUT 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/playbooks/qp96egozepn58mg93wein1e8pe' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'\
             -d '{"title": "Playbook","team_id": "ni8duypfe7bamprxqeffd563gy","create_public_incident": true,"checklists": [{"title": "Title","items": [{"title": "Title"}]}]}'
       responses:
@@ -886,7 +886,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X DELETE 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v1/playbooks/qp96egozepn58mg93wein1e8pe' \
+            curl -X DELETE 'http://localhost:8065/plugins/com.mattermost.plugin-incident-response/api/v0/playbooks/qp96egozepn58mg93wein1e8pe' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:

--- a/server/api/api_test.go
+++ b/server/api/api_test.go
@@ -15,7 +15,7 @@ func TestAPI(t *testing.T) {
 	}{
 		"404": {
 			test: func(t *testing.T, handler *Handler, writer *httptest.ResponseRecorder) {
-				req := httptest.NewRequest("POST", "/api/v1/nothing", nil)
+				req := httptest.NewRequest("POST", "/api/v0/nothing", nil)
 				handler.ServeHTTP(writer, req, "")
 				resp := writer.Result()
 				defer resp.Body.Close()

--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -90,7 +90,7 @@ func TestIncidents(t *testing.T) {
 		incidentService.EXPECT().CreateIncident(&i, true).Return(&retI, nil)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
+		testreq, err := http.NewRequest("POST", "/api/v0/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -146,7 +146,7 @@ func TestIncidents(t *testing.T) {
 		incidentService.EXPECT().CreateIncident(&i, true).Return(&retI, nil)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
+		testreq, err := http.NewRequest("POST", "/api/v0/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -197,7 +197,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(false)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
+		testreq, err := http.NewRequest("POST", "/api/v0/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -260,7 +260,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PRIVATE_CHANNEL).Return(false)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
+		testreq, err := http.NewRequest("POST", "/api/v0/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -306,7 +306,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
+		testreq, err := http.NewRequest("POST", "/api/v0/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -357,7 +357,7 @@ func TestIncidents(t *testing.T) {
 		require.NoError(t, err)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/incidents", bytes.NewBuffer(incidentJSON))
+		testreq, err := http.NewRequest("POST", "/api/v0/incidents", bytes.NewBuffer(incidentJSON))
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -399,7 +399,7 @@ func TestIncidents(t *testing.T) {
 		require.NoError(t, err)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/incidents", bytes.NewBuffer(incidentJSON))
+		testreq, err := http.NewRequest("POST", "/api/v0/incidents", bytes.NewBuffer(incidentJSON))
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -432,7 +432,7 @@ func TestIncidents(t *testing.T) {
 		require.NoError(t, err)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/incidents", bytes.NewBuffer(incidentJSON))
+		testreq, err := http.NewRequest("POST", "/api/v0/incidents", bytes.NewBuffer(incidentJSON))
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -458,7 +458,7 @@ func TestIncidents(t *testing.T) {
 		require.NoError(t, err)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/incidents", bytes.NewBuffer(incidentJSON))
+		testreq, err := http.NewRequest("POST", "/api/v0/incidents", bytes.NewBuffer(incidentJSON))
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -486,7 +486,7 @@ func TestIncidents(t *testing.T) {
 		require.NoError(t, err)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/incidents", bytes.NewBuffer(incidentJSON))
+		testreq, err := http.NewRequest("POST", "/api/v0/incidents", bytes.NewBuffer(incidentJSON))
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -520,7 +520,7 @@ func TestIncidents(t *testing.T) {
 		incidentService.EXPECT().GetIncident("incidentID").Return(&testIncident, nil)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/channel/"+testIncidentHeader.ChannelID, nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/channel/"+testIncidentHeader.ChannelID, nil)
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -555,7 +555,7 @@ func TestIncidents(t *testing.T) {
 		logger.EXPECT().Warnf("User %s does not have permissions to get incident for channel %s", userID, testIncidentHeader.ChannelID)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/channel/"+testIncidentHeader.ChannelID, nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/channel/"+testIncidentHeader.ChannelID, nil)
 		testreq.Header.Add("Mattermost-User-ID", userID)
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -585,7 +585,7 @@ func TestIncidents(t *testing.T) {
 		logger.EXPECT().Warnf(gomock.Any(), gomock.Any())
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/channel/"+testIncidentHeader.ChannelID, nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/channel/"+testIncidentHeader.ChannelID, nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -624,7 +624,7 @@ func TestIncidents(t *testing.T) {
 			Return(&testIncident, nil)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID, nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/"+testIncident.ID, nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -663,7 +663,7 @@ func TestIncidents(t *testing.T) {
 			Return(&testIncident, nil).Times(2)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID, nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/"+testIncident.ID, nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -709,7 +709,7 @@ func TestIncidents(t *testing.T) {
 			Return(&testIncident, nil)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID, nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/"+testIncident.ID, nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -750,7 +750,7 @@ func TestIncidents(t *testing.T) {
 			Return(&testIncident, nil).Times(2)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID, nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/"+testIncident.ID, nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -794,7 +794,7 @@ func TestIncidents(t *testing.T) {
 			Return(&testIncident, nil).Times(2)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID, nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/"+testIncident.ID, nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -838,7 +838,7 @@ func TestIncidents(t *testing.T) {
 			Return(&testIncident, nil)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID+"/details", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/"+testIncident.ID+"/details", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -892,7 +892,7 @@ func TestIncidents(t *testing.T) {
 			Return(&testIncidentDetails, nil)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID+"/details", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/"+testIncident.ID+"/details", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -938,7 +938,7 @@ func TestIncidents(t *testing.T) {
 			Return(&testIncident, nil)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID+"/details", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/"+testIncident.ID+"/details", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -994,7 +994,7 @@ func TestIncidents(t *testing.T) {
 			Return(&testIncidentDetails, nil)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID+"/details", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/"+testIncident.ID+"/details", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -1053,7 +1053,7 @@ func TestIncidents(t *testing.T) {
 			Return(&testIncidentDetails, nil)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents/"+testIncident.ID+"/details", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents/"+testIncident.ID+"/details", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -1094,7 +1094,7 @@ func TestIncidents(t *testing.T) {
 		incidentService.EXPECT().GetIncidents(gomock.Any(), gomock.Any()).Return(result, nil)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents?team_id=testTeamID1", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents?team_id=testTeamID1", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -1121,7 +1121,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(false)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/incidents?team_id=non-existent", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/incidents?team_id=non-existent", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testUserID")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -1289,7 +1289,7 @@ func TestChangeActiveStage(t *testing.T) {
 			testrecorder := httptest.NewRecorder()
 			updatesJSON, err := json.Marshal(data.updateOptions)
 			require.NoError(t, err)
-			testreq, err := http.NewRequest("PATCH", "/api/v1/incidents/"+data.oldIncident.ID, bytes.NewBuffer(updatesJSON))
+			testreq, err := http.NewRequest("PATCH", "/api/v0/incidents/"+data.oldIncident.ID, bytes.NewBuffer(updatesJSON))
 			testreq.Header.Add("Mattermost-User-ID", "testUserID")
 			require.NoError(t, err)
 			handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -1387,7 +1387,7 @@ func TestEndIncident(t *testing.T) {
 					}
 
 					recorder := httptest.NewRecorder()
-					req, err := http.NewRequest(method, "/api/v1/incidents/"+incidentID+"/end", nil)
+					req, err := http.NewRequest(method, "/api/v0/incidents/"+incidentID+"/end", nil)
 					require.NoError(t, err)
 
 					if tc.AuthorizationFunc != nil {

--- a/server/api/playbooks_test.go
+++ b/server/api/playbooks_test.go
@@ -113,7 +113,7 @@ func TestPlaybooks(t *testing.T) {
 		pluginAPI.On("HasPermissionToTeam", "testuserid", "testteamid", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/playbooks", jsonPlaybookReader(playbooktest))
+		testreq, err := http.NewRequest("POST", "/api/v0/playbooks", jsonPlaybookReader(playbooktest))
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -127,7 +127,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/playbooks/testplaybookid", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/playbooks/testplaybookid", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -165,7 +165,7 @@ func TestPlaybooks(t *testing.T) {
 		}
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/playbooks?team_id=testteamid", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/playbooks?team_id=testteamid", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -201,7 +201,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("PUT", "/api/v1/playbooks/testplaybookid", jsonPlaybookReader(playbooktest))
+		testreq, err := http.NewRequest("PUT", "/api/v0/playbooks/testplaybookid", jsonPlaybookReader(playbooktest))
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -233,7 +233,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("DELETE", "/api/v1/playbooks/testplaybookid", nil)
+		testreq, err := http.NewRequest("DELETE", "/api/v0/playbooks/testplaybookid", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -265,7 +265,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("DELETE", "/api/v1/playbooks/testplaybookid", nil)
+		testreq, err := http.NewRequest("DELETE", "/api/v0/playbooks/testplaybookid", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -287,7 +287,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/playbooks", jsonPlaybookReader(playbooktest))
+		testreq, err := http.NewRequest("POST", "/api/v0/playbooks", jsonPlaybookReader(playbooktest))
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -304,7 +304,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/playbooks/testplaybookid", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/playbooks/testplaybookid", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -326,7 +326,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/playbooks?team_id=testteamid", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/playbooks?team_id=testteamid", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -343,7 +343,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("PUT", "/api/v1/playbooks/testplaybookid", jsonPlaybookReader(withid))
+		testreq, err := http.NewRequest("PUT", "/api/v0/playbooks/testplaybookid", jsonPlaybookReader(withid))
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -365,7 +365,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("POST", "/api/v1/playbooks", jsonPlaybookReader(withid))
+		testreq, err := http.NewRequest("POST", "/api/v0/playbooks", jsonPlaybookReader(withid))
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
@@ -379,7 +379,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/playbooks/playbookwithmember", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/playbooks/playbookwithmember", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -405,7 +405,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/playbooks/playbookwithmember", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/playbooks/playbookwithmember", nil)
 		testreq.Header.Add("Mattermost-User-ID", "unknownMember")
 		require.NoError(t, err)
 
@@ -428,7 +428,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("PUT", "/api/v1/playbooks/playbookwithmember", jsonPlaybookReader(playbooktest))
+		testreq, err := http.NewRequest("PUT", "/api/v0/playbooks/playbookwithmember", jsonPlaybookReader(playbooktest))
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -463,7 +463,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("PUT", "/api/v1/playbooks/playbookwithmember", jsonPlaybookReader(playbooktest))
+		testreq, err := http.NewRequest("PUT", "/api/v0/playbooks/playbookwithmember", jsonPlaybookReader(playbooktest))
 		testreq.Header.Add("Mattermost-User-ID", "unknownMember")
 		require.NoError(t, err)
 
@@ -494,7 +494,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("DELETE", "/api/v1/playbooks/playbookwithmember", nil)
+		testreq, err := http.NewRequest("DELETE", "/api/v0/playbooks/playbookwithmember", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -526,7 +526,7 @@ func TestPlaybooks(t *testing.T) {
 		reset()
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("DELETE", "/api/v1/playbooks/playbookwithmember", nil)
+		testreq, err := http.NewRequest("DELETE", "/api/v0/playbooks/playbookwithmember", nil)
 		testreq.Header.Add("Mattermost-User-ID", "unknownMember")
 		require.NoError(t, err)
 
@@ -561,7 +561,7 @@ func TestPlaybooks(t *testing.T) {
 		}
 
 		testrecorder := httptest.NewRecorder()
-		testreq, err := http.NewRequest("GET", "/api/v1/playbooks?team_id=testteamid", nil)
+		testreq, err := http.NewRequest("GET", "/api/v0/playbooks?team_id=testteamid", nil)
 		testreq.Header.Add("Mattermost-User-ID", "testuserid")
 		require.NoError(t, err)
 
@@ -792,7 +792,7 @@ func TestSortingPlaybooks(t *testing.T) {
 			}
 
 			testrecorder := httptest.NewRecorder()
-			testreq, err := http.NewRequest("GET", fmt.Sprintf("/api/v1/playbooks?team_id=testteamid&sort=%s&direction=%s", data.sortField, data.sortDirection), nil)
+			testreq, err := http.NewRequest("GET", fmt.Sprintf("/api/v0/playbooks?team_id=testteamid&sort=%s&direction=%s", data.sortField, data.sortDirection), nil)
 			testreq.Header.Add("Mattermost-User-ID", "testuserid")
 			require.NoError(t, err)
 
@@ -1005,7 +1005,7 @@ func TestPagingPlaybooks(t *testing.T) {
 			reset()
 
 			testrecorder := httptest.NewRecorder()
-			testreq, err := http.NewRequest("GET", fmt.Sprintf("/api/v1/playbooks?team_id=testteamid&page=%s&per_page=%s", data.page, data.perPage), nil)
+			testreq, err := http.NewRequest("GET", fmt.Sprintf("/api/v0/playbooks?team_id=testteamid&page=%s&per_page=%s", data.page, data.perPage), nil)
 			testreq.Header.Add("Mattermost-User-ID", "testuserid")
 			require.NoError(t, err)
 

--- a/server/api/subscriptions_test.go
+++ b/server/api/subscriptions_test.go
@@ -132,7 +132,7 @@ func TestCreateSubscription(t *testing.T) {
 			subscriptionJSON, err := json.Marshal(test.subsc)
 			require.NoError(t, err)
 
-			request, err := http.NewRequest("POST", "/api/v1/eventsubscriptions", bytes.NewBuffer(subscriptionJSON))
+			request, err := http.NewRequest("POST", "/api/v0/eventsubscriptions", bytes.NewBuffer(subscriptionJSON))
 			require.NoError(t, err)
 			request.Header.Add("Mattermost-User-ID", test.requestUser)
 

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -86,7 +86,7 @@ func getAutocompleteData() *model.AutocompleteData {
 		"Checks or unchecks a checklist item.")
 	checklist.AddDynamicListArgument(
 		"List of checklist items is downloading from your incident response plugin",
-		"api/v1/incidents/checklist-autocomplete", true)
+		"api/v0/incidents/checklist-autocomplete", true)
 	slashIncident.AddCommand(checklist)
 
 	announce := model.NewAutocompleteData("announce", "~[channels]",

--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -141,7 +141,7 @@ func (s *ServiceImpl) OpenCreateIncidentDialog(teamID, commanderID, triggerID, p
 	}
 
 	dialogRequest := model.OpenDialogRequest{
-		URL: fmt.Sprintf("/plugins/%s/api/v1/incidents/dialog",
+		URL: fmt.Sprintf("/plugins/%s/api/v0/incidents/dialog",
 			s.configService.GetManifest().Id),
 		Dialog:    *dialog,
 		TriggerId: triggerID,
@@ -250,7 +250,7 @@ func (s *ServiceImpl) OpenEndIncidentDialog(incidentID, triggerID string) error 
 
 	dialogRequest := model.OpenDialogRequest{
 		URL: fmt.Sprintf(
-			"/plugins/%s/api/v1/incidents/%s/end",
+			"/plugins/%s/api/v0/incidents/%s/end",
 			s.configService.GetManifest().Id,
 			incidentID,
 		),
@@ -611,7 +611,7 @@ func (s *ServiceImpl) OpenNextStageDialog(incidentID string, nextStage int, trig
 	}
 
 	dialogRequest := model.OpenDialogRequest{
-		URL: fmt.Sprintf("/plugins/%s/api/v1/incidents/%s/next-stage-dialog",
+		URL: fmt.Sprintf("/plugins/%s/api/v0/incidents/%s/next-stage-dialog",
 			s.configService.GetManifest().Id,
 			incidentID,
 		),

--- a/tests-e2e/cypress/support/endpoints.json
+++ b/tests-e2e/cypress/support/endpoints.json
@@ -1,3 +1,3 @@
 {
-	"incidents": "/plugins/com.mattermost.plugin-incident-response/api/v1/incidents"
+	"incidents": "/plugins/com.mattermost.plugin-incident-response/api/v0/incidents"
 }

--- a/tests-e2e/cypress/support/plugin_api_commands.js
+++ b/tests-e2e/cypress/support/plugin_api_commands.js
@@ -11,7 +11,7 @@ const incidentsEndpoint = endpoints.incidents;
 Cypress.Commands.add('apiGetAllIncidents', (teamId) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: `/plugins/com.mattermost.plugin-incident-response/api/v1/incidents?team_id=${teamId}`,
+        url: `/plugins/com.mattermost.plugin-incident-response/api/v0/incidents?team_id=${teamId}`,
         method: 'GET',
     }).then((response) => {
         expect(response.status).to.equal(200);
@@ -122,7 +122,7 @@ Cypress.Commands.add('verifyIncidentEnded', (teamId, incidentName) => {
 Cypress.Commands.add('apiCreatePlaybook', ({teamId, title, createPublicIncident, checklists, memberIDs}) => {
     return cy.request({
         headers: {'X-Requested-With': 'XMLHttpRequest'},
-        url: '/plugins/com.mattermost.plugin-incident-response/api/v1/playbooks',
+        url: '/plugins/com.mattermost.plugin-incident-response/api/v0/playbooks',
         method: 'POST',
         body: {
             title,

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -31,7 +31,7 @@ import {
 
 import {pluginId} from './manifest';
 
-const apiUrl = `/plugins/${pluginId}/api/v1`;
+const apiUrl = `/plugins/${pluginId}/api/v0`;
 
 export async function fetchIncidents(params: FetchIncidentsParams) {
     const queryParams = qs.stringify(params, {addQueryPrefix: true});
@@ -241,7 +241,7 @@ export async function setActiveStage(incidentId: string, activeStage: number) {
 }
 
 export function exportChannelUrl(channelId: string) {
-    const exportPluginUrl = '/plugins/com.mattermost.plugin-channel-export/api/v1';
+    const exportPluginUrl = '/plugins/com.mattermost.plugin-channel-export/api/v0';
 
     const queryParams = qs.stringify({
         channel_id: channelId,


### PR DESCRIPTION
#### Summary

Just that, replacing all occurrences of `v1` with `v0`.

I considered coding a simple function that builds the API url prefix and call that from all the places that are using a path, but it's too late to fight paths and double slashes and stuff that will break before code freeze. So good old replace. We can do the right thing when we move to v1.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29286