### PR TITLE
MM-29608 - Fix for RHS List across teams

### DIFF
--- a/tests-e2e/cypress/integration/frontstage/incident_creation_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_creation_spec.js
@@ -57,7 +57,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started with slash command
             const incidentName = 'Public ' + Date.now();
             cy.startIncidentWithSlashCommand(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a private channel', () => {
@@ -67,7 +67,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started with slash command
             const incidentName = 'Private ' + Date.now();
             cy.startIncidentWithSlashCommand(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a group message channel', () => {
@@ -80,7 +80,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started with slash command
             const incidentName = 'Public ' + Date.now();
             cy.startIncidentWithSlashCommand(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a direct message channel with another user', () => {
@@ -93,7 +93,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started with slash command
             const incidentName = 'Public ' + Date.now();
             cy.startIncidentWithSlashCommand(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a direct message channel with self', () => {
@@ -106,7 +106,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started with slash command
             const incidentName = 'Public ' + Date.now();
             cy.startIncidentWithSlashCommand(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
     });
 
@@ -118,7 +118,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started from incident RHS
             const incidentName = 'Public - ' + Date.now();
             cy.startIncidentFromRHS(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a private channel', () => {
@@ -128,7 +128,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started from incident RHS
             const incidentName = 'Private - ' + Date.now();
             cy.startIncidentFromRHS(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a group message channel', () => {
@@ -141,7 +141,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started from incident RHS
             const incidentName = 'GM - ' + Date.now();
             cy.startIncidentFromRHS(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a direct message channel with another user', () => {
@@ -154,7 +154,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started from incident RHS
             const incidentName = 'DM - ' + Date.now();
             cy.startIncidentFromRHS(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a direct message channel with self', () => {
@@ -167,7 +167,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started with slash command
             const incidentName = 'Self DM ' + Date.now();
             cy.startIncidentWithSlashCommand(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
     });
 
@@ -179,7 +179,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started from post menu
             const incidentName = 'Public - ' + Date.now();
             cy.startIncidentFromPostMenu(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a private channel', () => {
@@ -189,7 +189,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started from post menu
             const incidentName = 'Private - ' + Date.now();
             cy.startIncidentFromPostMenu(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a group message channel', () => {
@@ -202,7 +202,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started from post menu
             const incidentName = 'GM - ' + Date.now();
             cy.startIncidentFromPostMenu(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a direct message channel with another user', () => {
@@ -215,7 +215,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started from post menu
             const incidentName = 'DM - ' + Date.now();
             cy.startIncidentFromPostMenu(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
 
         it('while viewing a direct message channel with self', () => {
@@ -228,7 +228,7 @@ describe('incidents can be started', () => {
             // * Verify that incident can be started from post menu
             const incidentName = 'Self DM - ' + Date.now();
             cy.startIncidentFromPostMenu(playbookName, incidentName);
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
         });
     });
 
@@ -241,6 +241,6 @@ describe('incidents can be started', () => {
         const incidentName = 'With Description - ' + now;
         const incidentDescription = 'Description - ' + now;
         cy.startIncidentWithSlashCommand(playbookName, incidentName, incidentDescription);
-        cy.verifyIncidentCreated(teamId, incidentName, incidentDescription);
+        cy.verifyIncidentActive(teamId, incidentName, incidentDescription);
     });
 });

--- a/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
@@ -340,6 +340,7 @@ describe('rhs incident list', () => {
         });
 
         it('of the current team, not another teams channels', () => {
+            // # Remove all active incidents so that we can verify the number of incidents in the rhs list later
             cy.endAllMyActiveIncidents(teamId);
             cy.endAllMyActiveIncidents(teamIdMi);
 

--- a/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
@@ -149,6 +149,99 @@ describe('rhs incident list', () => {
     });
 
     describe('should see the complete incident list', () => {
+        it('of the current team, not another teams channels', () => {
+            cy.endAllMyActiveIncidents(teamId);
+            cy.endAllMyActiveIncidents(teamIdMi);
+
+            // # Navigate directly to a non-incident channel
+            cy.visit('/ad-1/channels/town-square');
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Click the incident icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click();
+            });
+
+            // # start first incident
+            const now = Date.now();
+            const incidentName1 = 'Private ' + now;
+            cy.apiStartIncident({
+                teamId,
+                playbookId,
+                incidentName: incidentName1,
+                commanderUserId: userId
+            });
+            cy.verifyIncidentActive(teamId, incidentName1);
+
+            // * Verify the rhs list is still open and incident is visible.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Your Ongoing Incidents').should('exist');
+
+                // * Verify incident is visible
+                cy.findByText(incidentName1).should('exist');
+
+                // * Verify only one incident is visible
+                cy.findAllByTestId('go-to-channel').should('have.length', 1);
+            });
+
+            // # Go to second team (not directly, we want redux to not be wiped)
+            cy.get('#reiciendis-0TeamButton').should('exist').click();
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Click the incident icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click();
+            });
+
+            // # start second incident
+            const now2 = Date.now();
+            const incidentName2 = 'Private ' + now2;
+            cy.apiStartIncident({
+                teamId: teamIdMi,
+                playbookId: playbookIdMi,
+                incidentName: incidentName2,
+                commanderUserId: userId
+            });
+            cy.verifyIncidentActive(teamIdMi, incidentName2);
+
+            // * Verify the rhs list is still open and incident is visible.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Your Ongoing Incidents').should('exist');
+
+                // * Verify incident2 is visible
+                cy.findByText(incidentName2).should('exist');
+
+                // * Verify only one incident is visible
+                cy.findAllByTestId('go-to-channel').should('have.length', 1);
+            });
+
+            // # Go to first team (not directly, we want redux to not be wiped)
+            cy.get('#ad-1TeamButton').should('exist').click();
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Click the incident icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click();
+            });
+
+            // * Verify the rhs list is open and only one incident is visible.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Your Ongoing Incidents').should('exist');
+
+                // * Verify incident is visible
+                cy.findByText(incidentName1).should('exist');
+
+                // * Verify only that one incident is visible
+                cy.findAllByTestId('go-to-channel').should('have.length', 1);
+            });
+        });
+
         it('after creating two incidents and moving back to town-square', () => {
             cy.endAllMyActiveIncidents(teamId);
 
@@ -336,99 +429,6 @@ describe('rhs incident list', () => {
                 cy.findByText('Your Ongoing Incidents').should('exist');
 
                 cy.findByText(incidentName).should('exist');
-            });
-        });
-
-        it('of the current team, not another teams channels', () => {
-            cy.endAllMyActiveIncidents(teamId);
-            cy.endAllMyActiveIncidents(teamIdMi);
-
-            // # Navigate directly to a non-incident channel
-            cy.visit('/ad-1/channels/town-square');
-
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-            // # Click the incident icon
-            cy.get('#channel-header').within(() => {
-                cy.get('#incidentIcon').should('exist').click();
-            });
-
-            // # start first incident
-            const now = Date.now();
-            const incidentName1 = 'Private ' + now;
-            cy.apiStartIncident({
-                teamId,
-                playbookId,
-                incidentName: incidentName1,
-                commanderUserId: userId
-            });
-            cy.verifyIncidentActive(teamId, incidentName1);
-
-            // * Verify the rhs list is still open and incident is visible.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText('Your Ongoing Incidents').should('exist');
-
-                // * Verify incident is visible
-                cy.findByText(incidentName1).should('exist');
-
-                // * Verify only one incident is visible
-                cy.findAllByTestId('go-to-channel').should('have.length', 1);
-            });
-
-            // # Go to second team (not directly, we want redux to not be wiped)
-            cy.get('#reiciendis-0TeamButton').should('exist').click();
-
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-            // # Click the incident icon
-            cy.get('#channel-header').within(() => {
-                cy.get('#incidentIcon').should('exist').click();
-            });
-
-            // # start second incident
-            const now2 = Date.now();
-            const incidentName2 = 'Private ' + now2;
-            cy.apiStartIncident({
-                teamId: teamIdMi,
-                playbookId: playbookIdMi,
-                incidentName: incidentName2,
-                commanderUserId: userId
-            });
-            cy.verifyIncidentActive(teamIdMi, incidentName2);
-
-            // * Verify the rhs list is still open and incident is visible.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText('Your Ongoing Incidents').should('exist');
-
-                // * Verify incident2 is visible
-                cy.findByText(incidentName2).should('exist');
-
-                // * Verify only one incident is visible
-                cy.findAllByTestId('go-to-channel').should('have.length', 1);
-            });
-
-            // # Go to first team (not directly, we want redux to not be wiped)
-            cy.get('#ad-1TeamButton').should('exist').click();
-
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-            // # Click the incident icon
-            cy.get('#channel-header').within(() => {
-                cy.get('#incidentIcon').should('exist').click();
-            });
-
-            // * Verify the rhs list is open and only one incident is visible.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText('Your Ongoing Incidents').should('exist');
-
-                // * Verify incident is visible
-                cy.findByText(incidentName1).should('exist');
-
-                // * Verify only that one incident is visible
-                cy.findAllByTestId('go-to-channel').should('have.length', 1);
             });
         });
     });

--- a/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
@@ -149,99 +149,6 @@ describe('rhs incident list', () => {
     });
 
     describe('should see the complete incident list', () => {
-        it('of the current team, not another teams channels', () => {
-            cy.endAllMyActiveIncidents(teamId);
-            cy.endAllMyActiveIncidents(teamIdMi);
-
-            // # Navigate directly to a non-incident channel
-            cy.visit('/ad-1/channels/town-square');
-
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-            // # Click the incident icon
-            cy.get('#channel-header').within(() => {
-                cy.get('#incidentIcon').should('exist').click();
-            });
-
-            // # start first incident
-            const now = Date.now();
-            const incidentName1 = 'Private ' + now;
-            cy.apiStartIncident({
-                teamId,
-                playbookId,
-                incidentName: incidentName1,
-                commanderUserId: userId
-            });
-            cy.verifyIncidentActive(teamId, incidentName1);
-
-            // * Verify the rhs list is still open and incident is visible.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText('Your Ongoing Incidents').should('exist');
-
-                // * Verify incident is visible
-                cy.findByText(incidentName1).should('exist');
-
-                // * Verify only one incident is visible
-                cy.findAllByTestId('go-to-channel').should('have.length', 1);
-            });
-
-            // # Go to second team (not directly, we want redux to not be wiped)
-            cy.get('#reiciendis-0TeamButton').should('exist').click();
-
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-            // # Click the incident icon
-            cy.get('#channel-header').within(() => {
-                cy.get('#incidentIcon').should('exist').click();
-            });
-
-            // # start second incident
-            const now2 = Date.now();
-            const incidentName2 = 'Private ' + now2;
-            cy.apiStartIncident({
-                teamId: teamIdMi,
-                playbookId: playbookIdMi,
-                incidentName: incidentName2,
-                commanderUserId: userId
-            });
-            cy.verifyIncidentActive(teamIdMi, incidentName2);
-
-            // * Verify the rhs list is still open and incident is visible.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText('Your Ongoing Incidents').should('exist');
-
-                // * Verify incident2 is visible
-                cy.findByText(incidentName2).should('exist');
-
-                // * Verify only one incident is visible
-                cy.findAllByTestId('go-to-channel').should('have.length', 1);
-            });
-
-            // # Go to first team (not directly, we want redux to not be wiped)
-            cy.get('#ad-1TeamButton').should('exist').click();
-
-            // # Ensure the channel is loaded before continuing (allows redux to sync).
-            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
-
-            // # Click the incident icon
-            cy.get('#channel-header').within(() => {
-                cy.get('#incidentIcon').should('exist').click();
-            });
-
-            // * Verify the rhs list is open and only one incident is visible.
-            cy.get('#rhsContainer').should('exist').within(() => {
-                cy.findByText('Your Ongoing Incidents').should('exist');
-
-                // * Verify incident is visible
-                cy.findByText(incidentName1).should('exist');
-
-                // * Verify only that one incident is visible
-                cy.findAllByTestId('go-to-channel').should('have.length', 1);
-            });
-        });
-
         it('after creating two incidents and moving back to town-square', () => {
             cy.endAllMyActiveIncidents(teamId);
 
@@ -429,6 +336,99 @@ describe('rhs incident list', () => {
                 cy.findByText('Your Ongoing Incidents').should('exist');
 
                 cy.findByText(incidentName).should('exist');
+            });
+        });
+
+        it('of the current team, not another teams channels', () => {
+            cy.endAllMyActiveIncidents(teamId);
+            cy.endAllMyActiveIncidents(teamIdMi);
+
+            // # Navigate directly to a non-incident channel
+            cy.visit('/ad-1/channels/town-square');
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Click the incident icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click();
+            });
+
+            // # start first incident
+            const now = Date.now();
+            const incidentName1 = 'Private ' + now;
+            cy.apiStartIncident({
+                teamId,
+                playbookId,
+                incidentName: incidentName1,
+                commanderUserId: userId
+            });
+            cy.verifyIncidentActive(teamId, incidentName1);
+
+            // * Verify the rhs list is still open and incident is visible.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Your Ongoing Incidents').should('exist');
+
+                // * Verify incident is visible
+                cy.findByText(incidentName1).should('exist');
+
+                // * Verify only one incident is visible
+                cy.findAllByTestId('go-to-channel').should('have.length', 1);
+            });
+
+            // # Go to second team (not directly, we want redux to not be wiped)
+            cy.get('#reiciendis-0TeamButton').should('exist').click();
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Click the incident icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click();
+            });
+
+            // # start second incident
+            const now2 = Date.now();
+            const incidentName2 = 'Private ' + now2;
+            cy.apiStartIncident({
+                teamId: teamIdMi,
+                playbookId: playbookIdMi,
+                incidentName: incidentName2,
+                commanderUserId: userId
+            });
+            cy.verifyIncidentActive(teamIdMi, incidentName2);
+
+            // * Verify the rhs list is still open and incident is visible.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Your Ongoing Incidents').should('exist');
+
+                // * Verify incident2 is visible
+                cy.findByText(incidentName2).should('exist');
+
+                // * Verify only one incident is visible
+                cy.findAllByTestId('go-to-channel').should('have.length', 1);
+            });
+
+            // # Go to first team (not directly, we want redux to not be wiped)
+            cy.get('#ad-1TeamButton').should('exist').click();
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Click the incident icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click();
+            });
+
+            // * Verify the rhs list is open and only one incident is visible.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Your Ongoing Incidents').should('exist');
+
+                // * Verify incident is visible
+                cy.findByText(incidentName1).should('exist');
+
+                // * Verify only that one incident is visible
+                cy.findAllByTestId('go-to-channel').should('have.length', 1);
             });
         });
     });

--- a/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
@@ -100,7 +100,7 @@ describe('rhs incident list', () => {
                 commanderUserId: userId
             }).then((incident) => {
                 const incidentId = incident.id;
-                cy.verifyIncidentCreated(teamId, incidentName);
+                cy.verifyIncidentActive(teamId, incidentName);
 
                 // # move to non-incident channel
                 cy.get('#sidebarItem_town-square').click();
@@ -149,11 +149,11 @@ describe('rhs incident list', () => {
             const now = Date.now();
             let incidentName = 'Private ' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             incidentName = 'Private ' + Date.now();
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // * Verify the rhs list is still open and two go-to-channel buttons are visible.
             cy.get('#rhsContainer').should('exist').within(() => {
@@ -175,7 +175,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # Open the incident channel from the LHS.
             cy.get(`#sidebarItem_${incidentChannelName}`).click();
@@ -218,7 +218,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # Open the incident channel from the LHS.
             cy.get(`#sidebarItem_${incidentChannelName}`).click();
@@ -265,7 +265,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # Open the incident channel from the LHS.
             cy.get(`#sidebarItem_${incidentChannelName}`).click();
@@ -297,7 +297,7 @@ describe('rhs incident list', () => {
             const now = Date.now();
             const incidentName = 'Incident (' + now + ')';
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # Visit a private channel: autem-2
             cy.visit('/ad-1/channels/autem-2');
@@ -334,7 +334,7 @@ describe('rhs incident list', () => {
             const now = Date.now();
             const incidentName = 'Incident (' + now + ')';
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # Click the incident icon
             cy.get('#channel-header').within(() => {
@@ -371,7 +371,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # Open the incident channel from the LHS.
             cy.get(`#sidebarItem_${incidentChannelName}`).click();
@@ -422,7 +422,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             now = Date.now() + 1;
             const secondIncidentName = 'Incident (' + now + ')';
@@ -433,7 +433,7 @@ describe('rhs incident list', () => {
                 incidentName: secondIncidentName,
                 commanderUserId: userId
             });
-            cy.verifyIncidentCreated(teamId, secondIncidentName);
+            cy.verifyIncidentActive(teamId, secondIncidentName);
 
             // # Open the incident channel from the LHS.
             cy.get(`#sidebarItem_${secondIncidentChannelName}`).click();
@@ -485,7 +485,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             now = Date.now() + 1;
             const secondIncidentName = 'Incident (' + now + ')';
@@ -495,7 +495,7 @@ describe('rhs incident list', () => {
                 incidentName: secondIncidentName,
                 commanderUserId: userId
             });
-            cy.verifyIncidentCreated(teamId, secondIncidentName);
+            cy.verifyIncidentActive(teamId, secondIncidentName);
 
             // # Open the incident channel from the LHS.
             cy.get(`#sidebarItem_${incidentChannelName}`).click();
@@ -538,7 +538,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # Open the incident channel from the LHS.
             cy.get(`#sidebarItem_${incidentChannelName}`).click();
@@ -596,7 +596,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # Open the incident channel from the LHS.
             cy.get(`#sidebarItem_${incidentChannelName}`).click();
@@ -663,7 +663,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbook2Id, incidentName, commanderUserId: user2Id});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # add user-1 to the incident
             let channelId;
@@ -692,7 +692,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # Open the incident channel from the LHS.
             cy.get(`#sidebarItem_${incidentChannelName}`).click();
@@ -741,7 +741,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbook2Id, incidentName, commanderUserId: user2Id});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # add user-1 to the incident
             cy.apiGetChannelByName('ad-1', incidentChannelName).then(({channel}) => {
@@ -779,7 +779,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # Open the incident channel from the LHS.
             cy.get(`#sidebarItem_${incidentChannelName}`).click();
@@ -848,7 +848,7 @@ describe('rhs incident list', () => {
             }).then((incident) => {
                 incidentId = incident.id;
             });
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # add user-1 to the incident
             cy.apiGetChannelByName('ad-1', incidentChannelName).then(({channel}) => {
@@ -896,7 +896,7 @@ describe('rhs incident list', () => {
                 commanderUserId: userId
             }).then((incident) => {
                 incidentId = incident.id;
-                cy.verifyIncidentCreated(teamId, incidentName);
+                cy.verifyIncidentActive(teamId, incidentName);
 
                 // * Verify the rhs list is open and we can see the new incident
                 cy.get('#rhsContainer').should('exist').within(() => {
@@ -906,7 +906,9 @@ describe('rhs incident list', () => {
                 });
 
                 // # User-1 closes the incident
-                cy.apiEndIncident(incidentId);
+                // TODO: Waiting here because of https://mattermost.atlassian.net/browse/MM-29617
+                cy.wait(500).apiEndIncident(incidentId);
+                cy.verifyIncidentEnded(teamId, incidentName);
 
                 // * Verify we cannot see the incident
                 cy.get('#rhsContainer').should('exist').within(() => {
@@ -917,6 +919,7 @@ describe('rhs incident list', () => {
 
                 // # User-1 restarts the incident
                 cy.apiRestartIncident(incidentId);
+                cy.verifyIncidentActive(teamId, incidentName);
 
                 // * Verify the rhs list is open and we can see the new incident
                 cy.get('#rhsContainer').should('exist').within(() => {
@@ -958,7 +961,7 @@ describe('rhs incident list', () => {
                 commanderUserId: user2Id
             }).then((incident) => {
                 const incidentId = incident.id;
-                cy.verifyIncidentCreated(teamId, incidentName);
+                cy.verifyIncidentActive(teamId, incidentName);
 
                 // # add user-1 to the incident
                 cy.apiGetChannelByName('ad-1', incidentChannelName).then(({channel}) => {
@@ -1009,7 +1012,7 @@ describe('rhs incident list', () => {
             const incidentName = 'Incident (' + now + ')';
             const incidentChannelName = 'incident-' + now;
             cy.apiStartIncident({teamId, playbookId, incidentName, commanderUserId: userId});
-            cy.verifyIncidentCreated(teamId, incidentName);
+            cy.verifyIncidentActive(teamId, incidentName);
 
             // # Open the incident channel from the LHS.
             cy.get(`#sidebarItem_${incidentChannelName}`).click();

--- a/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
@@ -4,11 +4,14 @@
 describe('rhs incident list', () => {
     const playbookName = 'Playbook (' + Date.now() + ')';
     const playbook2Name = 'Playbook (' + (Date.now() + 1) + ')';
+    const playbookNameMi = 'Playbook (' + (Date.now() + 2) + ')';
     let teamId;
+    let teamIdMi;
     let userId;
     let user2Id;
     let playbookId;
     let playbook2Id;
+    let playbookIdMi;
 
     before(() => {
         // # Login as user-1
@@ -26,6 +29,21 @@ describe('rhs incident list', () => {
                     userId: user.id,
                 }).then((playbook) => {
                     playbookId = playbook.id;
+                });
+            });
+        });
+
+        // # Prepare Reiciendis-0 team (Minus or Mi in the team bar)
+        cy.apiGetTeamByName('reiciendis-0').then((team) => {
+            teamIdMi = team.id;
+            cy.apiGetCurrentUser().then((user) => {
+                // # Create a playbook
+                cy.apiCreateTestPlaybook({
+                    teamId: team.id,
+                    title: playbookNameMi,
+                    userId: user.id,
+                }).then((playbook) => {
+                    playbookIdMi = playbook.id;
                 });
             });
         });
@@ -318,6 +336,99 @@ describe('rhs incident list', () => {
                 cy.findByText('Your Ongoing Incidents').should('exist');
 
                 cy.findByText(incidentName).should('exist');
+            });
+        });
+
+        it('of the current team, not another teams channels', () => {
+            cy.endAllMyActiveIncidents(teamId);
+            cy.endAllMyActiveIncidents(teamIdMi);
+
+            // # Navigate directly to a non-incident channel
+            cy.visit('/ad-1/channels/town-square');
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Click the incident icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click();
+            });
+
+            // # start first incident
+            const now = Date.now();
+            const incidentName1 = 'Private ' + now;
+            cy.apiStartIncident({
+                teamId,
+                playbookId,
+                incidentName: incidentName1,
+                commanderUserId: userId
+            });
+            cy.verifyIncidentActive(teamId, incidentName1);
+
+            // * Verify the rhs list is still open and incident is visible.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Your Ongoing Incidents').should('exist');
+
+                // * Verify incident is visible
+                cy.findByText(incidentName1).should('exist');
+
+                // * Verify only one incident is visible
+                cy.findAllByTestId('go-to-channel').should('have.length', 1);
+            });
+
+            // # Go to second team (not directly, we want redux to not be wiped)
+            cy.get('#reiciendis-0TeamButton').should('exist').click();
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Click the incident icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click();
+            });
+
+            // # start second incident
+            const now2 = Date.now();
+            const incidentName2 = 'Private ' + now2;
+            cy.apiStartIncident({
+                teamId: teamIdMi,
+                playbookId: playbookIdMi,
+                incidentName: incidentName2,
+                commanderUserId: userId
+            });
+            cy.verifyIncidentActive(teamIdMi, incidentName2);
+
+            // * Verify the rhs list is still open and incident is visible.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Your Ongoing Incidents').should('exist');
+
+                // * Verify incident2 is visible
+                cy.findByText(incidentName2).should('exist');
+
+                // * Verify only one incident is visible
+                cy.findAllByTestId('go-to-channel').should('have.length', 1);
+            });
+
+            // # Go to first team (not directly, we want redux to not be wiped)
+            cy.get('#ad-1TeamButton').should('exist').click();
+
+            // # Ensure the channel is loaded before continuing (allows redux to sync).
+            cy.get('#centerChannelFooter').findByTestId('post_textbox').should('exist');
+
+            // # Click the incident icon
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist').click();
+            });
+
+            // * Verify the rhs list is open and only one incident is visible.
+            cy.get('#rhsContainer').should('exist').within(() => {
+                cy.findByText('Your Ongoing Incidents').should('exist');
+
+                // * Verify incident is visible
+                cy.findByText(incidentName1).should('exist');
+
+                // * Verify only that one incident is visible
+                cy.findAllByTestId('go-to-channel').should('have.length', 1);
             });
         });
     });

--- a/tests-e2e/cypress/support/plugin_api_commands.js
+++ b/tests-e2e/cypress/support/plugin_api_commands.js
@@ -139,7 +139,7 @@ Cypress.Commands.add('apiChangeIncidentCommander', (incidentId, userId) => {
 });
 
 // Verify incident is created
-Cypress.Commands.add('verifyIncidentCreated', (teamId, incidentName, incidentDescription) => {
+Cypress.Commands.add('verifyIncidentActive', (teamId, incidentName, incidentDescription) => {
     cy.apiGetIncidentByName(teamId, incidentName).then((response) => {
         const returnedIncidents = JSON.parse(response.body);
         const incident = returnedIncidents.items.find((inc) => inc.name === incidentName);
@@ -155,7 +155,7 @@ Cypress.Commands.add('verifyIncidentCreated', (teamId, incidentName, incidentDes
     });
 });
 
-// Verify incident is not created
+// Verify incident exists but is not active
 Cypress.Commands.add('verifyIncidentEnded', (teamId, incidentName) => {
     cy.apiGetIncidentByName(teamId, incidentName).then((response) => {
         const returnedIncidents = JSON.parse(response.body);

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -140,7 +140,8 @@ export const receivedTeamIncidents = (incidents: Incident[]): ReceivedTeamIncide
     incidents,
 });
 
-export const removedFromIncidentChannel = (channelId: string): RemovedFromIncidentChannel => ({
+export const removedFromIncidentChannel = (teamId: string, channelId: string): RemovedFromIncidentChannel => ({
     type: REMOVED_FROM_INCIDENT_CHANNEL,
+    teamId,
     channelId,
 });

--- a/webapp/src/components/rhs/rhs_main.tsx
+++ b/webapp/src/components/rhs/rhs_main.tsx
@@ -9,7 +9,7 @@ import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/channels'
 
 import {setRHSOpen, setRHSViewingIncident, setRHSViewingList} from 'src/actions';
 import RHSListView from 'src/components/rhs/rhs_list_view';
-import {currentRHSState, isIncidentChannel} from 'src/selectors';
+import {currentRHSState, inIncidentChannel} from 'src/selectors';
 import {RHSState} from 'src/types/rhs';
 import RHSWelcomeView from 'src/components/rhs/rhs_welcome_view';
 import RHSDetailsView from 'src/components/rhs/rhs_details_view';
@@ -17,7 +17,7 @@ import RHSDetailsView from 'src/components/rhs/rhs_details_view';
 const RightHandSidebar: FC<null> = () => {
     const dispatch = useDispatch();
     const currentChannelId = useSelector<GlobalState, string>(getCurrentChannelId);
-    const inIncidentChannel = useSelector<GlobalState, boolean>((state) => isIncidentChannel(state, currentChannelId));
+    const inIncident = useSelector<GlobalState, boolean>(inIncidentChannel);
     const rhsState = useSelector<GlobalState, RHSState>(currentRHSState);
     const [seenChannelId, setSeenChannelId] = useState('');
 
@@ -32,7 +32,7 @@ const RightHandSidebar: FC<null> = () => {
     if (currentChannelId !== seenChannelId) {
         setSeenChannelId(currentChannelId);
 
-        if (inIncidentChannel) {
+        if (inIncident) {
             dispatch(setRHSViewingIncident());
         } else {
             dispatch(setRHSViewingList());
@@ -40,7 +40,7 @@ const RightHandSidebar: FC<null> = () => {
     }
 
     if (rhsState === RHSState.ViewingIncident) {
-        if (inIncidentChannel) {
+        if (inIncident) {
             return <RHSDetailsView/>;
         }
         return <RHSWelcomeView/>;

--- a/webapp/src/rhs_opener.ts
+++ b/webapp/src/rhs_opener.ts
@@ -9,7 +9,7 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
 import {fetchIncidents} from 'src/client';
 
-import {isIncidentRHSOpen, isIncidentChannel} from 'src/selectors';
+import {isIncidentRHSOpen, inIncidentChannel} from 'src/selectors';
 import {toggleRHS, receivedTeamIncidents} from 'src/actions';
 
 export function makeRHSOpener(store: Store<GlobalState>): () => Promise<void> {
@@ -47,7 +47,7 @@ export function makeRHSOpener(store: Store<GlobalState>): () => Promise<void> {
             return;
         }
         currentChannelId = currentChannel.id;
-        currentChannelIsIncident = isIncidentChannel(state, currentChannelId);
+        currentChannelIsIncident = inIncidentChannel(state);
 
         // Don't do anything if the incident RHS is already open.
         if (isIncidentRHSOpen(state)) {

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -40,15 +40,10 @@ export const myActiveIncidentsList = createSelector(
             return [];
         }
 
-        const incidents = [] as Incident[];
-        for (const incident of Object.values(incidentMapByTeam[teamId])) {
-            if (incident.is_active) {
-                incidents.push(incident);
-            }
-        }
-
-        // return descending by create_at
-        return incidents.sort((a, b) => b.create_at - a.create_at);
+        // return active incidents, sorted descending by create_at
+        return Object.values(incidentMapByTeam[teamId]).
+            filter((i) => i.is_active).
+            sort((a, b) => b.create_at - a.create_at);
     },
 );
 

--- a/webapp/src/slash_command.ts
+++ b/webapp/src/slash_command.ts
@@ -1,10 +1,9 @@
 import {Store} from 'redux';
-import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {generateId} from 'mattermost-redux/utils/helpers';
 
 import {toggleRHS, setClientId} from 'src/actions';
-import {isIncidentChannel, isIncidentRHSOpen} from 'src/selectors';
+import {inIncidentChannel, isIncidentRHSOpen} from 'src/selectors';
 
 export function makeSlashCommandHook(store: Store<GlobalState>) {
     return (message: string, args = {}) => {
@@ -24,9 +23,8 @@ export function makeSlashCommandHook(store: Store<GlobalState>) {
 
         if (messageTrimmed && messageTrimmed.startsWith('/incident info')) {
             const state = store.getState();
-            const currentChannel = getCurrentChannel(state);
 
-            if (isIncidentChannel(state, currentChannel.id) && !isIncidentRHSOpen(state)) {
+            if (inIncidentChannel(state) && !isIncidentRHSOpen(state)) {
                 //@ts-ignore thunk
                 store.dispatch(toggleRHS());
 

--- a/webapp/src/types/actions.ts
+++ b/webapp/src/types/actions.ts
@@ -53,6 +53,7 @@ export interface ReceivedTeamIncidents {
 
 export interface RemovedFromIncidentChannel {
     type: typeof REMOVED_FROM_INCIDENT_CHANNEL;
+    teamId: string;
     channelId: string;
 }
 

--- a/webapp/src/websocket_events.ts
+++ b/webapp/src/websocket_events.ts
@@ -7,6 +7,7 @@ import {GetStateFunc} from 'mattermost-redux/types/actions';
 import {WebSocketMessage} from 'mattermost-redux/actions/websocket';
 import {getCurrentTeam, getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import {navigateToUrl} from 'src/browser_routing';
 import {
@@ -96,7 +97,8 @@ export function handleWebsocketUserRemoved(getState: GetStateFunc, dispatch: Dis
     return (msg: WebSocketMessage) => {
         const currentUserId = getCurrentUserId(getState());
         if (currentUserId === msg.broadcast.user_id) {
-            dispatch(removedFromIncidentChannel(msg.data.channel_id));
+            const channel = getChannel(getState(), msg.data.channel_id);
+            dispatch(removedFromIncidentChannel(channel.team_id, channel.id));
         }
     };
 }


### PR DESCRIPTION
#### Summary
- This changes how the redux works -- it's now a map to a map: `{teamId: {channelId: Incident}}`. True, we could keep it all in a `{channelId: Incident}` flatter map, but I think that makes unnecessary waste in the selectors. The downside is the complicated reducer state spreading to avoid mutating the store. Would appreciate a double check if you're able.
- I fixed how we were using reselectors--it's making more sense to me now.
- Oh! I'm a huge fan of TDD with cypress--it helped catch a huge bug in an earlier version of this (I was sending a message to clear the store when we changed channels, but that solution is racy -- this current implementation isn't).

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-29608