### PR TITLE
MM-29380: remove create playbook prompt on mobile

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -189,7 +189,13 @@ func (r *Runner) actionStart(args []string) {
 		return
 	}
 
-	if err := r.incidentService.OpenCreateIncidentDialog(r.args.TeamId, r.args.UserId, r.args.TriggerId, postID, clientID, playbooksResults.Items); err != nil {
+	session, err := r.pluginAPI.Session.Get(r.context.SessionId)
+	if err != nil {
+		r.warnUserAndLogErrorf("Error retrieving session: %v", err)
+		return
+	}
+
+	if err := r.incidentService.OpenCreateIncidentDialog(r.args.TeamId, r.args.UserId, r.args.TriggerId, postID, clientID, playbooksResults.Items, session.IsMobileApp()); err != nil {
 		r.warnUserAndLogErrorf("Error: %v", err)
 		return
 	}

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -160,7 +160,7 @@ type Service interface {
 	CreateIncident(incdnt *Incident, public bool) (*Incident, error)
 
 	// OpenCreateIncidentDialog opens an interactive dialog to start a new incident.
-	OpenCreateIncidentDialog(teamID, commanderID, triggerID, postID, clientID string, playbooks []playbook.Playbook) error
+	OpenCreateIncidentDialog(teamID, commanderID, triggerID, postID, clientID string, playbooks []playbook.Playbook, isMobileApp bool) error
 
 	// EndIncident completes the incident with the given ID by the given user.
 	EndIncident(incidentID string, userID string) error

--- a/server/incident/mocks/mock_service.go
+++ b/server/incident/mocks/mock_service.go
@@ -5,12 +5,11 @@
 package mock_incident
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	incident "github.com/mattermost/mattermost-plugin-incident-response/server/incident"
 	playbook "github.com/mattermost/mattermost-plugin-incident-response/server/playbook"
 	model "github.com/mattermost/mattermost-server/v5/model"
+	reflect "reflect"
 )
 
 // MockService is a mock of Service interface
@@ -255,17 +254,17 @@ func (mr *MockServiceMockRecorder) NukeDB() *gomock.Call {
 }
 
 // OpenCreateIncidentDialog mocks base method
-func (m *MockService) OpenCreateIncidentDialog(arg0, arg1, arg2, arg3, arg4 string, arg5 []playbook.Playbook) error {
+func (m *MockService) OpenCreateIncidentDialog(arg0, arg1, arg2, arg3, arg4 string, arg5 []playbook.Playbook, arg6 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenCreateIncidentDialog", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "OpenCreateIncidentDialog", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // OpenCreateIncidentDialog indicates an expected call of OpenCreateIncidentDialog
-func (mr *MockServiceMockRecorder) OpenCreateIncidentDialog(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) OpenCreateIncidentDialog(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenCreateIncidentDialog", reflect.TypeOf((*MockService)(nil).OpenCreateIncidentDialog), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenCreateIncidentDialog", reflect.TypeOf((*MockService)(nil).OpenCreateIncidentDialog), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // OpenEndIncidentDialog mocks base method

--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -134,8 +134,8 @@ func (s *ServiceImpl) CreateIncident(incdnt *Incident, public bool) (*Incident, 
 }
 
 // OpenCreateIncidentDialog opens a interactive dialog to start a new incident.
-func (s *ServiceImpl) OpenCreateIncidentDialog(teamID, commanderID, triggerID, postID, clientID string, playbooks []playbook.Playbook) error {
-	dialog, err := s.newIncidentDialog(teamID, commanderID, postID, clientID, playbooks)
+func (s *ServiceImpl) OpenCreateIncidentDialog(teamID, commanderID, triggerID, postID, clientID string, playbooks []playbook.Playbook, isMobileApp bool) error {
+	dialog, err := s.newIncidentDialog(teamID, commanderID, postID, clientID, playbooks, isMobileApp)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create new incident dialog")
 	}
@@ -825,7 +825,7 @@ func (s *ServiceImpl) createIncidentChannel(incdnt *Incident, public bool) (*mod
 	return channel, nil
 }
 
-func (s *ServiceImpl) newIncidentDialog(teamID, commanderID, postID, clientID string, playbooks []playbook.Playbook) (*model.Dialog, error) {
+func (s *ServiceImpl) newIncidentDialog(teamID, commanderID, postID, clientID string, playbooks []playbook.Playbook, isMobileApp bool) (*model.Dialog, error) {
 	team, err := s.pluginAPI.Team.Get(teamID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to fetch team")
@@ -854,7 +854,7 @@ func (s *ServiceImpl) newIncidentDialog(teamID, commanderID, postID, clientID st
 
 	siteURL := s.pluginAPI.Configuration.GetConfig().ServiceSettings.SiteURL
 	newPlaybookMarkdown := ""
-	if siteURL != nil && *siteURL != "" {
+	if siteURL != nil && *siteURL != "" && !isMobileApp {
 		url := fmt.Sprintf("%s/%s/%s/playbooks/new", *siteURL, team.Name, s.configService.GetManifest().Id)
 		newPlaybookMarkdown = fmt.Sprintf(" [Create a playbook.](%s)", url)
 	}

--- a/server/incident/service_test.go
+++ b/server/incident/service_test.go
@@ -370,24 +370,6 @@ func TestChangeActiveStage(t *testing.T) {
 }
 
 func TestOpenCreateIncidentDialog(t *testing.T) {
-	// testIncident := incident.Incident{
-	// 	Header: incident.Header{
-	// 		ID:               "incidentID",
-	// 		CommanderUserID:  "testUserID",
-	// 		TeamID:           "testTeamID",
-	// 		Name:             "incidentName",
-	// 		ChannelID:        "channelID",
-	// 		IsActive:         true,
-	// 		ActiveStage:      0,
-	// 		ActiveStageTitle: "Stage 2",
-	// 	},
-	// 	PostID: "",
-	// 	Checklists: []playbook.Checklist{
-	// 		{Title: "Stage 1"},
-	// 		{Title: "Stage 2"},
-	// 	},
-	// }
-
 	siteURL := "https://mattermost.example.com"
 
 	type args struct {

--- a/server/incident/service_test.go
+++ b/server/incident/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-incident-response/server/telemetry"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -358,12 +359,157 @@ func TestChangeActiveStage(t *testing.T) {
 
 			changedIncident, err := service.ChangeActiveStage(tt.args.incidentID, tt.args.userID, 1)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("RestartIncident() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ChangeActiveStage() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
 			require.Equal(t, changedIncident.ActiveStage, 1)
 			require.Equal(t, changedIncident.ActiveStageTitle, "Stage 2")
+		})
+	}
+}
+
+func TestOpenCreateIncidentDialog(t *testing.T) {
+	// testIncident := incident.Incident{
+	// 	Header: incident.Header{
+	// 		ID:               "incidentID",
+	// 		CommanderUserID:  "testUserID",
+	// 		TeamID:           "testTeamID",
+	// 		Name:             "incidentName",
+	// 		ChannelID:        "channelID",
+	// 		IsActive:         true,
+	// 		ActiveStage:      0,
+	// 		ActiveStageTitle: "Stage 2",
+	// 	},
+	// 	PostID: "",
+	// 	Checklists: []playbook.Checklist{
+	// 		{Title: "Stage 1"},
+	// 		{Title: "Stage 2"},
+	// 	},
+	// }
+
+	siteURL := "https://mattermost.example.com"
+
+	type args struct {
+		teamID      string
+		commanderID string
+		triggerID   string
+		postID      string
+		clientID    string
+		playbooks   []playbook.Playbook
+		isMobileApp bool
+	}
+	tests := []struct {
+		name      string
+		args      args
+		prepMocks func(t *testing.T, store *mock_incident.MockStore, poster *mock_poster.MockPoster, api *plugintest.API, configService *mock_config.MockService)
+		wantErr   bool
+	}{
+		{
+			name: "successful webapp invocation without SiteURL",
+			args: args{
+				teamID:      "teamID",
+				commanderID: "commanderID",
+				triggerID:   "triggerID",
+				postID:      "postID",
+				clientID:    "clientID",
+				playbooks:   []playbook.Playbook{},
+				isMobileApp: false,
+			},
+			prepMocks: func(t *testing.T, store *mock_incident.MockStore, poster *mock_poster.MockPoster, api *plugintest.API, configService *mock_config.MockService) {
+				api.On("GetTeam", "teamID").
+					Return(&model.Team{Id: "teamID", Name: "Team"}, nil)
+				api.On("GetUser", "commanderID").
+					Return(&model.User{Id: "commanderID", Username: "User"}, nil)
+				api.On("GetConfig").
+					Return(&model.Config{})
+				configService.EXPECT().GetManifest().Return(&model.Manifest{Id: "pluginId"}).Times(2)
+				api.On("OpenInteractiveDialog", mock.AnythingOfType("model.OpenDialogRequest")).Return(nil).Run(func(args mock.Arguments) {
+					dialogRequest := args.Get(0).(model.OpenDialogRequest)
+					assert.NotContains(t, dialogRequest.Dialog.IntroductionText, "Create a playbook")
+				})
+			},
+			wantErr: false,
+		},
+		{
+			name: "successful webapp invocation",
+			args: args{
+				teamID:      "teamID",
+				commanderID: "commanderID",
+				triggerID:   "triggerID",
+				postID:      "postID",
+				clientID:    "clientID",
+				playbooks:   []playbook.Playbook{},
+				isMobileApp: false,
+			},
+			prepMocks: func(t *testing.T, store *mock_incident.MockStore, poster *mock_poster.MockPoster, api *plugintest.API, configService *mock_config.MockService) {
+				api.On("GetTeam", "teamID").
+					Return(&model.Team{Id: "teamID", Name: "Team"}, nil)
+				api.On("GetUser", "commanderID").
+					Return(&model.User{Id: "commanderID", Username: "User"}, nil)
+				api.On("GetConfig").
+					Return(&model.Config{
+						ServiceSettings: model.ServiceSettings{
+							SiteURL: &siteURL,
+						},
+					})
+				configService.EXPECT().GetManifest().Return(&model.Manifest{Id: "pluginId"}).Times(2)
+				api.On("OpenInteractiveDialog", mock.AnythingOfType("model.OpenDialogRequest")).Return(nil).Run(func(args mock.Arguments) {
+					dialogRequest := args.Get(0).(model.OpenDialogRequest)
+					assert.Contains(t, dialogRequest.Dialog.IntroductionText, "Create a playbook")
+				})
+			},
+			wantErr: false,
+		},
+		{
+			name: "successful mobile app invocation",
+			args: args{
+				teamID:      "teamID",
+				commanderID: "commanderID",
+				triggerID:   "triggerID",
+				postID:      "postID",
+				clientID:    "clientID",
+				playbooks:   []playbook.Playbook{},
+				isMobileApp: true,
+			},
+			prepMocks: func(t *testing.T, store *mock_incident.MockStore, poster *mock_poster.MockPoster, api *plugintest.API, configService *mock_config.MockService) {
+				api.On("GetTeam", "teamID").
+					Return(&model.Team{Id: "teamID", Name: "Team"}, nil)
+				api.On("GetUser", "commanderID").
+					Return(&model.User{Id: "commanderID", Username: "User"}, nil)
+				api.On("GetConfig").
+					Return(&model.Config{
+						ServiceSettings: model.ServiceSettings{
+							SiteURL: &siteURL,
+						},
+					})
+				configService.EXPECT().GetManifest().Return(&model.Manifest{Id: "pluginId"}).Times(2)
+				api.On("OpenInteractiveDialog", mock.AnythingOfType("model.OpenDialogRequest")).Return(nil).Run(func(args mock.Arguments) {
+					dialogRequest := args.Get(0).(model.OpenDialogRequest)
+					assert.NotContains(t, dialogRequest.Dialog.IntroductionText, "Create a playbook")
+				})
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			api := &plugintest.API{}
+			client := pluginapi.NewClient(api)
+			store := mock_incident.NewMockStore(controller)
+			poster := mock_poster.NewMockPoster(controller)
+			configService := mock_config.NewMockService(controller)
+			telemetryService := &telemetry.NoopTelemetry{}
+			service := incident.NewService(client, store, poster, configService, telemetryService)
+
+			tt.prepMocks(t, store, poster, api, configService)
+
+			err := service.OpenCreateIncidentDialog(tt.args.teamID, tt.args.commanderID, tt.args.triggerID, tt.args.postID, tt.args.clientID, tt.args.playbooks, tt.args.isMobileApp)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OpenCreateIncidentDialog() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### Summary
It's not possible to create a playbook on mobile, so tweak the `/incident start` interactive dialog to avoid mentioning this at all when invoked from mobile.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29380