### PR TITLE
MM-29699: Fix crash after /incident stage with no arguments

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -584,6 +584,7 @@ func (r *Runner) actionEnd() {
 func (r *Runner) actionStage(args []string) {
 	if len(args) != 1 {
 		r.postCommandResponse("`/incident stage` expects one argument: either `next` or `prev`")
+		return
 	}
 
 	switch strings.ToLower(args[0]) {

--- a/tests-e2e/cypress/integration/frontstage/slash_command/stage_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/slash_command/stage_spec.js
@@ -99,6 +99,19 @@ describe('slash command > stage', () => {
                 cy.visit('/ad-1/channels/town-square');
             });
 
+            it('without arguments', () => {
+                // # Run a slash command with no arguments
+                cy.executeSlashCommand('/incident stage');
+
+                // * Verify the expected error message.
+                cy.verifyEphemeralMessage('/incident stage expects one argument: either next or prev');
+
+                // * Verify that the incident did not crash
+                cy.get('#postCreateFooter').within(() => {
+                    cy.get('div.has-error').should('not.exist');
+                });
+            });
+
             it('/incident stage next', () => {
                 // # Run a slash command to go to next stage
                 cy.executeSlashCommand('/incident stage next');
@@ -120,6 +133,19 @@ describe('slash command > stage', () => {
             beforeEach(() => {
                 // # Navigate directly to the application and the incident channel
                 cy.visit('/ad-1/channels/' + incidentChannelName);
+            });
+
+            it('without arguments', () => {
+                // # Run a slash command with no arguments
+                cy.executeSlashCommand('/incident stage');
+
+                // * Verify the expected error message.
+                cy.verifyEphemeralMessage('/incident stage expects one argument: either next or prev');
+
+                // * Verify that the incident did not crash
+                cy.get('#postCreateFooter').within(() => {
+                    cy.get('div.has-error').should('not.exist');
+                });
             });
 
             describe('/incident stage next', () => {


### PR DESCRIPTION
#### Summary
There was a missing return after the check for no arguments, so although the help text informing the user was posted, the function kept running. As the code following that check assumed that there was at least one argument, it panicked when trying to retrieve it.

I've also added an E2E test covering this case. I check that no error is posted in the footer but, if the plugin crashes, all remaining tests will fail. That is, we will know that something is wrong one way or another.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29699