### PR TITLE
MM-26182: Standardize filtering parameters

### DIFF
--- a/client/doc.go
+++ b/client/doc.go
@@ -27,7 +27,7 @@ Some API methods have optional parameters that can be passed. For example:
 
 	// list incidents by status
 	list, err := client.Incidents.List(context.Background(), ir.IncidentListOptions{
-		Sort: ir.ByStatus,
+		Sort: ir.ByIsActive,
 	})
 
 Using the https://godoc.org/context package, one can easily

--- a/client/incidents.go
+++ b/client/incidents.go
@@ -69,9 +69,6 @@ const (
 
 	// EndAt sorts by the "end_at" field.
 	EndAt IncidentSort = "end_at"
-
-	// ByStatus sorts by the "status" field.
-	ByStatus IncidentSort = "by_status"
 )
 
 // IncidentList contains the paginated result.

--- a/client/incidents.go
+++ b/client/incidents.go
@@ -45,7 +45,7 @@ type IncidentListOptions struct {
 	TeamID string `url:"team_id,omitempty"`
 
 	Sort      IncidentSort  `url:"sort,omitempty"`
-	Direction SortDirection `url:"order,omitempty"`
+	Direction SortDirection `url:"direction,omitempty"`
 }
 
 // IncidentSort enumerates the available fields we can sort on.

--- a/server/api/api.yaml
+++ b/server/api/api.yaml
@@ -44,7 +44,7 @@ paths:
           required: false
           schema:
             type: string
-        - name: order
+        - name: direction
           in: query
           description: Defaults to desc
           required: false

--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -901,7 +901,7 @@ func parseIncidentsFilterOptions(u *url.URL) (*incident.HeaderFilterOptions, err
 	}
 
 	sort := u.Query().Get("sort")
-	order := u.Query().Get("order")
+	direction := u.Query().Get("direction")
 
 	statusParam := strings.ToLower(u.Query().Get("status"))
 	var status incident.Status
@@ -926,7 +926,7 @@ func parseIncidentsFilterOptions(u *url.URL) (*incident.HeaderFilterOptions, err
 		Page:        page,
 		PerPage:     perPage,
 		Sort:        sort,
-		Order:       order,
+		Direction:   direction,
 		Status:      status,
 		CommanderID: commanderID,
 		SearchTerm:  searchTerm,

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -257,9 +257,9 @@ func parseGetPlaybooksOptions(u *url.URL) (playbook.Options, error) {
 	param = strings.ToLower(params.Get("direction"))
 	switch param {
 	case "asc", "":
-		sortDirection = playbook.OrderAsc
+		sortDirection = playbook.DirectionAsc
 	case "desc":
-		sortDirection = playbook.OrderDesc
+		sortDirection = playbook.DirectionDesc
 	default:
 		return playbook.Options{}, errors.Errorf("bad parameter 'direction' (%s): it should be empty or one of 'asc' or 'desc'", param)
 	}

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -182,7 +182,7 @@ func (r *Runner) actionStart(args []string) {
 	playbooksResults, err := r.playbookService.GetPlaybooksForTeam(requesterInfo, r.args.TeamId,
 		playbook.Options{
 			Sort:      playbook.SortByTitle,
-			Direction: playbook.OrderAsc,
+			Direction: playbook.DirectionAsc,
 		})
 	if err != nil {
 		r.warnUserAndLogErrorf("Error: %v", err)
@@ -373,12 +373,12 @@ func (r *Runner) actionList() {
 	}
 
 	options := incident.HeaderFilterOptions{
-		TeamID:   r.args.TeamId,
-		MemberID: r.args.UserId,
-		PerPage:  10,
-		Sort:     incident.SortByCreateAt,
-		Order:    incident.OrderDesc,
-		Status:   incident.Ongoing,
+		TeamID:    r.args.TeamId,
+		MemberID:  r.args.UserId,
+		PerPage:   10,
+		Sort:      incident.SortByCreateAt,
+		Direction: incident.DirectionDesc,
+		Status:    incident.Ongoing,
 	}
 
 	result, err := r.incidentService.GetIncidents(requesterInfo, options)

--- a/server/incident/filter_options.go
+++ b/server/incident/filter_options.go
@@ -61,7 +61,6 @@ const (
 	SortByCommanderUserID = "commander_user_id"
 	SortByTeamID          = "team_id"
 	SortByEndAt           = "end_at"
-	SortByStatus          = "status"
 	SortByIsActive        = "is_active"
 
 	DirectionAsc  = "asc"

--- a/server/incident/filter_options.go
+++ b/server/incident/filter_options.go
@@ -36,8 +36,8 @@ type HeaderFilterOptions struct {
 	// defaults to "create_at".
 	Sort string
 
-	// OrderBy orders by Asc (ascending), or Desc (descending); defaults to desc.
-	Order string
+	// Direction orders by Asc (ascending), or Desc (descending); defaults to desc.
+	Direction string
 
 	// Status filters by All, Ongoing, or Ended; defaults to All.
 	Status Status
@@ -49,7 +49,7 @@ type HeaderFilterOptions struct {
 	MemberID string
 
 	// SearchTerm returns results of the search term and respecting the other header filter options.
-	// The search term acts as a filter and respects the Sort and Order fields (i.e., results are
+	// The search term acts as a filter and respects the Sort and Direction fields (i.e., results are
 	// not returned in relevance order).
 	SearchTerm string
 }
@@ -64,8 +64,8 @@ const (
 	SortByStatus          = "status"
 	SortByIsActive        = "is_active"
 
-	OrderAsc  = "asc"
-	OrderDesc = "desc"
+	DirectionAsc  = "asc"
+	DirectionDesc = "desc"
 )
 
 func IsValidSortBy(sortBy string) bool {
@@ -83,8 +83,8 @@ func IsValidSortBy(sortBy string) bool {
 	return false
 }
 
-func IsValidOrderBy(orderBy string) bool {
-	return orderBy == OrderAsc || orderBy == OrderDesc
+func IsValidDirection(direction string) bool {
+	return direction == DirectionAsc || direction == DirectionDesc
 }
 
 func ValidateOptions(options *HeaderFilterOptions) error {
@@ -116,14 +116,14 @@ func ValidateOptions(options *HeaderFilterOptions) error {
 		return errors.New("bad parameter 'sort'")
 	}
 
-	order := strings.ToLower(options.Order)
-	switch order {
-	case OrderAsc, "": // default
-		options.Order = OrderAsc
-	case OrderDesc:
-		options.Order = OrderDesc
+	direction := strings.ToLower(options.Direction)
+	switch direction {
+	case DirectionAsc, "": // default
+		options.Direction = DirectionAsc
+	case DirectionDesc:
+		options.Direction = DirectionDesc
 	default:
-		return errors.New("bad parameter 'order_by'")
+		return errors.New("bad parameter 'direction'")
 	}
 
 	if options.CommanderID != "" && !model.IsValidId(options.CommanderID) {

--- a/server/playbook/filter_options.go
+++ b/server/playbook/filter_options.go
@@ -19,10 +19,10 @@ type SortDirection string
 
 const (
 	// Desc is descending order.
-	OrderDesc SortDirection = "DESC"
+	DirectionDesc SortDirection = "DESC"
 
 	// Asc is ascending order.
-	OrderAsc SortDirection = "ASC"
+	DirectionAsc SortDirection = "ASC"
 )
 
 // Options specifies the parameters when getting playbooks.
@@ -47,5 +47,5 @@ func IsValidSort(sort SortField) bool {
 }
 
 func IsValidDirection(direction SortDirection) bool {
-	return direction == OrderAsc || direction == OrderDesc
+	return direction == DirectionAsc || direction == DirectionDesc
 }

--- a/server/sqlstore/incident.go
+++ b/server/sqlstore/incident.go
@@ -112,7 +112,7 @@ func (s *incidentStore) GetIncidents(requesterInfo incident.RequesterInfo, optio
 		queryForTotal = queryForTotal.Where(sq.Like{column: fmt.Sprint("%", searchString, "%")})
 	}
 
-	queryForResults = queryForResults.OrderBy(fmt.Sprintf("%s %s", options.Sort, options.Order))
+	queryForResults = queryForResults.OrderBy(fmt.Sprintf("%s %s", options.Sort, options.Direction))
 
 	var rawIncidents []sqlIncident
 	if err := s.store.selectBuilder(s.store.db, &rawIncidents, queryForResults); err != nil {

--- a/server/sqlstore/incident_test.go
+++ b/server/sqlstore/incident_test.go
@@ -228,8 +228,8 @@ func TestGetIncidents(t *testing.T) {
 				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
 			},
 			Options: incident.HeaderFilterOptions{
-				TeamID: team1id,
-				Order:  "desc",
+				TeamID:    team1id,
+				Direction: "desc",
 			},
 			Want: incident.GetIncidentsResults{
 				TotalCount: 5,
@@ -246,9 +246,9 @@ func TestGetIncidents(t *testing.T) {
 				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
 			},
 			Options: incident.HeaderFilterOptions{
-				TeamID: team2id,
-				Sort:   incident.SortByCreateAt,
-				Order:  incident.OrderDesc,
+				TeamID:    team2id,
+				Sort:      incident.SortByCreateAt,
+				Direction: incident.DirectionDesc,
 			},
 			Want: incident.GetIncidentsResults{
 				TotalCount: 2,
@@ -453,11 +453,11 @@ func TestGetIncidents(t *testing.T) {
 				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
 			},
 			Options: incident.HeaderFilterOptions{
-				TeamID:  team1id,
-				Sort:    "end_at",
-				Order:   "desc",
-				Page:    1,
-				PerPage: 2,
+				TeamID:    team1id,
+				Sort:      "end_at",
+				Direction: "desc",
+				Page:      1,
+				PerPage:   2,
 			},
 			Want: incident.GetIncidentsResults{
 				TotalCount: 5,
@@ -497,7 +497,7 @@ func TestGetIncidents(t *testing.T) {
 				TeamID:      team1id,
 				Status:      incident.Ongoing,
 				CommanderID: commander3.UserID,
-				Order:       "desc",
+				Direction:   "desc",
 			},
 			Want: incident.GetIncidentsResults{
 				TotalCount: 1,
@@ -516,7 +516,7 @@ func TestGetIncidents(t *testing.T) {
 			Options: incident.HeaderFilterOptions{
 				TeamID:      team1id,
 				CommanderID: commander1.UserID,
-				Order:       "desc",
+				Direction:   "desc",
 				Sort:        "end_at",
 			},
 			Want: incident.GetIncidentsResults{
@@ -664,17 +664,17 @@ func TestGetIncidents(t *testing.T) {
 			ExpectedErr: errors.New("bad parameter 'team_id': must be 26 characters"),
 		},
 		{
-			Name: "bad parameter order by",
+			Name: "bad parameter direction by",
 			RequesterInfo: incident.RequesterInfo{
 				UserID:          lucy.ID,
 				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
 			},
 			Options: incident.HeaderFilterOptions{
-				TeamID: team2id,
-				Order:  "invalid order",
+				TeamID:    team2id,
+				Direction: "invalid direction",
 			},
 			Want:        incident.GetIncidentsResults{},
-			ExpectedErr: errors.New("bad parameter 'order_by'"),
+			ExpectedErr: errors.New("bad parameter 'direction'"),
 		},
 		{
 			Name: "bad commander id",
@@ -695,8 +695,8 @@ func TestGetIncidents(t *testing.T) {
 				UserID: bob.ID,
 			},
 			Options: incident.HeaderFilterOptions{
-				TeamID: team1id,
-				Order:  "desc",
+				TeamID:    team1id,
+				Direction: "desc",
 			},
 			Want: incident.GetIncidentsResults{
 				TotalCount: 5,

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -411,9 +411,9 @@ func sortOptionToSQL(sort playbook.SortField) string {
 
 func directionOptionToSQL(direction playbook.SortDirection) string {
 	switch direction {
-	case playbook.OrderAsc, "":
+	case playbook.DirectionAsc, "":
 		return "ASC"
-	case playbook.OrderDesc:
+	case playbook.DirectionDesc:
 		return "DESC"
 	default:
 		return ""

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -350,7 +350,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortByTitle,
-				Direction: playbook.OrderDesc,
+				Direction: playbook.DirectionDesc,
 			},
 			expected: playbook.GetPlaybooksResults{
 				TotalCount: 2,
@@ -369,7 +369,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortByStages,
-				Direction: playbook.OrderDesc,
+				Direction: playbook.DirectionDesc,
 			},
 			expected: playbook.GetPlaybooksResults{
 				TotalCount: 2,
@@ -425,7 +425,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortBySteps,
-				Direction: playbook.OrderDesc,
+				Direction: playbook.DirectionDesc,
 			},
 			expected: playbook.GetPlaybooksResults{
 				TotalCount: 4,
@@ -444,7 +444,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortByTitle,
-				Direction: playbook.OrderDesc,
+				Direction: playbook.DirectionDesc,
 			},
 			expected: playbook.GetPlaybooksResults{
 				TotalCount: 4,
@@ -481,7 +481,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortBySteps,
-				Direction: playbook.OrderAsc,
+				Direction: playbook.DirectionAsc,
 			},
 			expected: playbook.GetPlaybooksResults{
 				TotalCount: 4,
@@ -500,7 +500,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortBySteps,
-				Direction: playbook.OrderDesc,
+				Direction: playbook.DirectionDesc,
 			},
 			expected: playbook.GetPlaybooksResults{
 				TotalCount: 4,
@@ -537,7 +537,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortByStages,
-				Direction: playbook.OrderDesc,
+				Direction: playbook.DirectionDesc,
 			},
 			expected: playbook.GetPlaybooksResults{
 				TotalCount: 4,

--- a/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
+++ b/webapp/src/components/backstage/incidents/incident_list/incident_list.tsx
@@ -159,7 +159,7 @@ const BackstageIncidentList: FC = () => {
             page: 0,
             per_page: BACKSTAGE_LIST_PER_PAGE,
             sort: 'create_at',
-            order: 'desc',
+            direction: 'desc',
         },
     );
 
@@ -200,18 +200,18 @@ const BackstageIncidentList: FC = () => {
 
     function colHeaderClicked(colName: string) {
         if (fetchParams.sort === colName) {
-            // we're already sorting on this column; reverse the order
-            const newOrder = fetchParams.order === 'asc' ? 'desc' : 'asc';
-            setFetchParams({...fetchParams, order: newOrder});
+            // we're already sorting on this column; reverse the direction
+            const newDirection = fetchParams.direction === 'asc' ? 'desc' : 'asc';
+            setFetchParams({...fetchParams, direction: newDirection});
             return;
         }
 
         // change to a new column; default to descending for time-based columns, ascending otherwise
-        let newOrder = 'desc';
+        let newDirection = 'desc';
         if (['name', 'is_active'].indexOf(colName) !== -1) {
-            newOrder = 'asc';
+            newDirection = 'asc';
         }
-        setFetchParams({...fetchParams, sort: colName, order: newOrder});
+        setFetchParams({...fetchParams, sort: colName, direction: newDirection});
     }
 
     async function fetchCommanders() {
@@ -306,7 +306,7 @@ const BackstageIncidentList: FC = () => {
                         <div className='col-sm-3'>
                             <SortableColHeader
                                 name={'Name'}
-                                order={fetchParams.order ? fetchParams.order : 'desc'}
+                                direction={fetchParams.direction ? fetchParams.direction : 'desc'}
                                 active={fetchParams.sort ? fetchParams.sort === 'name' : false}
                                 onClick={() => colHeaderClicked('name')}
                             />
@@ -314,7 +314,7 @@ const BackstageIncidentList: FC = () => {
                         <div className='col-sm-2'>
                             <SortableColHeader
                                 name={'Status'}
-                                order={fetchParams.order ? fetchParams.order : 'desc'}
+                                direction={fetchParams.direction ? fetchParams.direction : 'desc'}
                                 active={fetchParams.sort ? fetchParams.sort === 'is_active' : false}
                                 onClick={() => colHeaderClicked('is_active')}
                             />
@@ -322,7 +322,7 @@ const BackstageIncidentList: FC = () => {
                         <div className='col-sm-2'>
                             <SortableColHeader
                                 name={'Start Time'}
-                                order={fetchParams.order ? fetchParams.order : 'desc'}
+                                direction={fetchParams.direction ? fetchParams.direction : 'desc'}
                                 active={fetchParams.sort ? fetchParams.sort === 'create_at' : false}
                                 onClick={() => colHeaderClicked('create_at')}
                             />
@@ -330,7 +330,7 @@ const BackstageIncidentList: FC = () => {
                         <div className='col-sm-2'>
                             <SortableColHeader
                                 name={'End Time'}
-                                order={fetchParams.order ? fetchParams.order : 'desc'}
+                                direction={fetchParams.direction ? fetchParams.direction : 'desc'}
                                 active={fetchParams.sort ? fetchParams.sort === 'end_at' : false}
                                 onClick={() => colHeaderClicked('end_at')}
                             />

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -56,7 +56,7 @@ const PlaybookList: FC = () => {
 
     function colHeaderClicked(colName: string) {
         if (fetchParams.sort === colName) {
-            // we're already sorting on this column; reverse the order
+            // we're already sorting on this column; reverse the direction
             const newSortDirection = fetchParams.direction === 'asc' ? 'desc' : 'asc';
             setFetchParams({...fetchParams, direction: newSortDirection});
             return;
@@ -230,7 +230,7 @@ const PlaybookList: FC = () => {
                                 <div className='col-sm-4'>
                                     <SortableColHeader
                                         name={'Name'}
-                                        order={fetchParams.direction}
+                                        direction={fetchParams.direction}
                                         active={fetchParams.sort === 'title'}
                                         onClick={() => colHeaderClicked('title')}
                                     />
@@ -238,7 +238,7 @@ const PlaybookList: FC = () => {
                                 <div className='col-sm-2'>
                                     <SortableColHeader
                                         name={'Stages'}
-                                        order={fetchParams.direction}
+                                        direction={fetchParams.direction}
                                         active={fetchParams.sort === 'stages'}
                                         onClick={() => colHeaderClicked('stages')}
                                     />
@@ -246,7 +246,7 @@ const PlaybookList: FC = () => {
                                 <div className='col-sm-2'>
                                     <SortableColHeader
                                         name={'Tasks'}
-                                        order={fetchParams.direction}
+                                        direction={fetchParams.direction}
                                         active={fetchParams.sort === 'steps'}
                                         onClick={() => colHeaderClicked('steps')}
                                     />

--- a/webapp/src/components/sortable_col_header.tsx
+++ b/webapp/src/components/sortable_col_header.tsx
@@ -11,15 +11,15 @@ const Header = styled.div`
 
 interface Props {
     name: string;
-    order: string;
+    direction: string;
     active: boolean;
     onClick: () => void;
 }
 
 export function SortableColHeader(props: Props) {
     const chevron = classNames('icon--small', 'ml-2', {
-        'icon-chevron-down': props.order === 'desc',
-        'icon-chevron-up': props.order === 'asc',
+        'icon-chevron-down': props.direction === 'desc',
+        'icon-chevron-up': props.direction === 'asc',
     });
 
     return (

--- a/webapp/src/types/incident.ts
+++ b/webapp/src/types/incident.ts
@@ -71,7 +71,7 @@ export interface FetchIncidentsParams {
     page?: number;
     per_page?: number;
     sort?: string;
-    order?: string;
+    direction?: string;
     status?: string;
     commander_user_id?: string;
     search_term?: string;


### PR DESCRIPTION
#### Summary
All collection endpoints that support `sort`, `direction` and `search_term` (namely, `GET /incidents` and `GET /incidents/channels`) are now consistent. However, there are collections endpoints that only support a subset of those parameters. I did not add any code to support the missing parameters because we don't need it right now (and because adding new code at this stage does not seem like a good idea). The endpoints that don't support everything are:
  - `GET /playbooks` does support `sort` and `direction`, but does not support `search_term`.
  - `GET /incidents/commanders` does not support `sort`, `order` nor `search_term`.

I also removed the `status` value for the `sort` parameter because it feels redundant:
- status filtering is usually done through the `status` parameter
- we also have the `is_active` value for the `sort` parameter, in case we wanna sort it this way

Also: all tests are passing, and the renaming was automatic, but I feel like it's a big change to push after E2E testing. What do you think (cc/ @prapti)?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26182