### PR TITLE
set RUDDER env for build artifacts only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,6 +292,7 @@ workflows:
             tags:
               only: /^v.*/
       - plugin-ci/build:
+          context: mattermost-plugin-incident-response-production
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
#### Summary
Avoid spamming telemetry from e2e tests by only setting the required RUDDER environment variables during the build step.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-29753