### PR TITLE
MM-26194: Standardize HTTP status codes

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -42,14 +42,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, sourcePlugin
 }
 
 // ReturnJSON writes the given pointer to object as json with a success response
-func ReturnJSON(w http.ResponseWriter, pointerToObject interface{}) {
+func ReturnJSON(w http.ResponseWriter, pointerToObject interface{}, httpStatus int) {
 	jsonBytes, err := json.Marshal(pointerToObject)
 	if err != nil {
 		HandleError(w, errors.Wrapf(err, "unable to marshal json"))
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(httpStatus)
 	_, _ = w.Write(jsonBytes)
 }
 

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -50,7 +50,10 @@ func ReturnJSON(w http.ResponseWriter, pointerToObject interface{}, httpStatus i
 	}
 
 	w.WriteHeader(httpStatus)
-	_, _ = w.Write(jsonBytes)
+	if _, err = w.Write(jsonBytes); err != nil {
+		HandleError(w, err)
+		return
+	}
 }
 
 // HandleError writes err as json into the response.

--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -159,17 +159,7 @@ func (h *IncidentHandler) updateIncident(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	jsonBytes, err := json.Marshal(updatedIncident)
-	if err != nil {
-		HandleError(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(jsonBytes); err != nil {
-		HandleError(w, err)
-		return
-	}
+	ReturnJSON(w, updatedIncident, http.StatusOK)
 }
 
 // createIncidentFromDialog handles the interactive dialog submission when a user presses confirm on
@@ -333,17 +323,7 @@ func (h *IncidentHandler) getIncidents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonBytes, err := json.Marshal(results)
-	if err != nil {
-		HandleError(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(jsonBytes); err != nil {
-		HandleError(w, err)
-		return
-	}
+	ReturnJSON(w, results, http.StatusOK)
 }
 
 // getIncident handles the /incidents/{id} endpoint.
@@ -363,17 +343,7 @@ func (h *IncidentHandler) getIncident(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonBytes, err := json.Marshal(incidentToGet)
-	if err != nil {
-		HandleError(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(jsonBytes); err != nil {
-		HandleError(w, err)
-		return
-	}
+	ReturnJSON(w, incidentToGet, http.StatusOK)
 }
 
 // getIncidentMetadata handles the /incidents/{id}/metadata endpoint.
@@ -394,17 +364,7 @@ func (h *IncidentHandler) getIncidentMetadata(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	jsonBytes, err := json.Marshal(incidentToGet)
-	if err != nil {
-		HandleError(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(jsonBytes); err != nil {
-		HandleError(w, err)
-		return
-	}
+	ReturnJSON(w, incidentToGet, http.StatusOK)
 }
 
 // getIncidentByChannel handles the /incidents/channel/{channel_id} endpoint.
@@ -438,17 +398,7 @@ func (h *IncidentHandler) getIncidentByChannel(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	jsonBytes, err := json.Marshal(incidentToGet)
-	if err != nil {
-		HandleError(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(jsonBytes); err != nil {
-		HandleError(w, err)
-		return
-	}
+	ReturnJSON(w, incidentToGet, http.StatusOK)
 }
 
 // endIncident handles the /incidents/{id}/end api endpoint.
@@ -519,17 +469,7 @@ func (h *IncidentHandler) getCommanders(w http.ResponseWriter, r *http.Request) 
 		commanders = []incident.CommanderInfo{}
 	}
 
-	jsonBytes, err := json.Marshal(commanders)
-	if err != nil {
-		HandleError(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(jsonBytes); err != nil {
-		HandleError(w, err)
-		return
-	}
+	ReturnJSON(w, commanders, http.StatusOK)
 }
 
 func (h *IncidentHandler) getChannels(w http.ResponseWriter, r *http.Request) {
@@ -565,17 +505,7 @@ func (h *IncidentHandler) getChannels(w http.ResponseWriter, r *http.Request) {
 		channelIds = append(channelIds, incident.ChannelID)
 	}
 
-	jsonBytes, err := json.Marshal(channelIds)
-	if err != nil {
-		HandleError(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(jsonBytes); err != nil {
-		HandleError(w, err)
-		return
-	}
+	ReturnJSON(w, channelIds, http.StatusOK)
 }
 
 // changeCommander handles the /incidents/{id}/change-commander api endpoint.
@@ -652,18 +582,7 @@ func (h *IncidentHandler) getChecklistAutocomplete(w http.ResponseWriter, r *htt
 		return
 	}
 
-	jsonBytes, err := json.Marshal(data)
-	if err != nil {
-		HandleError(w, err)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(jsonBytes); err != nil {
-		HandleError(w, err)
-		return
-	}
+	ReturnJSON(w, data, http.StatusOK)
 }
 
 func (h *IncidentHandler) itemSetState(w http.ResponseWriter, r *http.Request) {

--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -467,7 +467,6 @@ func (h *IncidentHandler) endIncident(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
 }
 
 // restartIncident handles the /incidents/{id}/restart api endpoint.
@@ -482,7 +481,6 @@ func (h *IncidentHandler) restartIncident(w http.ResponseWriter, r *http.Request
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
 }
 
 // getCommanders handles the /incidents/commanders api endpoint.
@@ -610,7 +608,6 @@ func (h *IncidentHandler) changeCommander(w http.ResponseWriter, r *http.Request
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
 }
 
 // nextStageDialog handles the interactive dialog submission when a user confirms they
@@ -638,7 +635,6 @@ func (h *IncidentHandler) nextStageDialog(w http.ResponseWriter, r *http.Request
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
 }
 
 // getChecklistAutocomplete handles the GET /incidents/checklists-autocomplete api endpoint
@@ -704,7 +700,6 @@ func (h *IncidentHandler) itemSetState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
 }
 
 func (h *IncidentHandler) itemSetAssignee(w http.ResponseWriter, r *http.Request) {
@@ -736,7 +731,6 @@ func (h *IncidentHandler) itemSetAssignee(w http.ResponseWriter, r *http.Request
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
 }
 
 func (h *IncidentHandler) itemRun(w http.ResponseWriter, r *http.Request) {
@@ -760,7 +754,6 @@ func (h *IncidentHandler) itemRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
 }
 
 func (h *IncidentHandler) addChecklistItem(w http.ResponseWriter, r *http.Request) {
@@ -792,7 +785,6 @@ func (h *IncidentHandler) addChecklistItem(w http.ResponseWriter, r *http.Reques
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
 }
 
 func (h *IncidentHandler) itemDelete(w http.ResponseWriter, r *http.Request) {
@@ -816,7 +808,6 @@ func (h *IncidentHandler) itemDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
 }
 
 func (h *IncidentHandler) itemRename(w http.ResponseWriter, r *http.Request) {
@@ -849,7 +840,6 @@ func (h *IncidentHandler) itemRename(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
 }
 
 func (h *IncidentHandler) reorderChecklist(w http.ResponseWriter, r *http.Request) {
@@ -877,7 +867,6 @@ func (h *IncidentHandler) reorderChecklist(w http.ResponseWriter, r *http.Reques
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status": "OK"}`))
 }
 
 func (h *IncidentHandler) postIncidentCreatedMessage(incdnt *incident.Incident, channelID string) error {

--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -97,7 +97,7 @@ func TestIncidents(t *testing.T) {
 
 		resp := testrecorder.Result()
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 	})
 
 	t.Run("create valid incident from dialog with description", func(t *testing.T) {
@@ -153,7 +153,7 @@ func TestIncidents(t *testing.T) {
 
 		resp := testrecorder.Result()
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 	})
 
 	t.Run("create incident from dialog - no permissions for public channels", func(t *testing.T) {
@@ -364,7 +364,7 @@ func TestIncidents(t *testing.T) {
 
 		resp := testrecorder.Result()
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 		var resultIncident incident.Incident
 		err = json.NewDecoder(resp.Body).Decode(&resultIncident)
@@ -406,7 +406,7 @@ func TestIncidents(t *testing.T) {
 
 		resp := testrecorder.Result()
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 		var resultIncident incident.Incident
 		err = json.NewDecoder(resp.Body).Decode(&resultIncident)
@@ -439,7 +439,7 @@ func TestIncidents(t *testing.T) {
 
 		resp := testrecorder.Result()
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
 	t.Run("create invalid incident - missing team", func(t *testing.T) {
@@ -465,7 +465,7 @@ func TestIncidents(t *testing.T) {
 
 		resp := testrecorder.Result()
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
 	t.Run("create invalid incident - channel id already set", func(t *testing.T) {
@@ -493,7 +493,7 @@ func TestIncidents(t *testing.T) {
 
 		resp := testrecorder.Result()
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
 	t.Run("get incident by channel id", func(t *testing.T) {

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -205,17 +205,7 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonBytes, err := json.Marshal(playbookResults)
-	if err != nil {
-		HandleError(w, err)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write(jsonBytes); err != nil {
-		HandleError(w, err)
-		return
-	}
+	ReturnJSON(w, playbookResults, http.StatusOK)
 }
 
 func (h *PlaybookHandler) hasPermissionsToPlaybook(thePlaybook playbook.Playbook, userID string) bool {

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -139,9 +139,6 @@ func (h *PlaybookHandler) updatePlaybook(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write([]byte(`{"status": "OK"}`)); err != nil {
-		HandleError(w, err)
-	}
 }
 
 func (h *PlaybookHandler) deletePlaybook(w http.ResponseWriter, r *http.Request) {
@@ -170,9 +167,6 @@ func (h *PlaybookHandler) deletePlaybook(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	if _, err = w.Write([]byte(`{"status": "OK"}`)); err != nil {
-		HandleError(w, err)
-	}
 }
 
 func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -49,7 +50,7 @@ func (h *PlaybookHandler) createPlaybook(w http.ResponseWriter, r *http.Request)
 
 	var pbook playbook.Playbook
 	if err := json.NewDecoder(r.Body).Decode(&pbook); err != nil {
-		HandleError(w, errors.Wrapf(err, "unable to decode playbook"))
+		HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode playbook", err)
 		return
 	}
 
@@ -78,7 +79,8 @@ func (h *PlaybookHandler) createPlaybook(w http.ResponseWriter, r *http.Request)
 	}{
 		ID: id,
 	}
-	ReturnJSON(w, &result)
+	w.Header().Add("Location", fmt.Sprintf("/api/v0/playbooks/%s", pbook.ID))
+	ReturnJSON(w, &result, http.StatusCreated)
 }
 
 func (h *PlaybookHandler) getPlaybook(w http.ResponseWriter, r *http.Request) {
@@ -100,7 +102,7 @@ func (h *PlaybookHandler) getPlaybook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ReturnJSON(w, &pbook)
+	ReturnJSON(w, &pbook, http.StatusOK)
 }
 
 func (h *PlaybookHandler) updatePlaybook(w http.ResponseWriter, r *http.Request) {
@@ -108,7 +110,7 @@ func (h *PlaybookHandler) updatePlaybook(w http.ResponseWriter, r *http.Request)
 	userID := r.Header.Get("Mattermost-User-ID")
 	var pbook playbook.Playbook
 	if err := json.NewDecoder(r.Body).Decode(&pbook); err != nil {
-		HandleError(w, errors.Wrap(err, "unable to decode playbook"))
+		HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode playbook", err)
 		return
 	}
 
@@ -167,7 +169,7 @@ func (h *PlaybookHandler) deletePlaybook(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusNoContent)
 	if _, err = w.Write([]byte(`{"status": "OK"}`)); err != nil {
 		HandleError(w, err)
 	}
@@ -179,7 +181,7 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 	userID := r.Header.Get("Mattermost-User-ID")
 	opts, err := parseGetPlaybooksOptions(r.URL)
 	if err != nil {
-		HandleError(w, err)
+		HandleErrorWithCode(w, http.StatusBadRequest, "failed to get playbooks", err)
 		return
 	}
 

--- a/server/api/playbooks_test.go
+++ b/server/api/playbooks_test.go
@@ -221,12 +221,7 @@ func TestPlaybooks(t *testing.T) {
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
 		resp := testrecorder.Result()
-		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		result, err := ioutil.ReadAll(resp.Body)
-
-		require.NoError(t, err)
-		assert.Equal(t, []byte(`{"status": "OK"}`), result)
 	})
 
 	t.Run("delete playbook", func(t *testing.T) {
@@ -253,12 +248,7 @@ func TestPlaybooks(t *testing.T) {
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
 		resp := testrecorder.Result()
-		defer resp.Body.Close()
 		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-		result, err := ioutil.ReadAll(resp.Body)
-
-		require.NoError(t, err)
-		assert.Equal(t, []byte(`{"status": "OK"}`), result)
 	})
 
 	t.Run("delete playbook no team permission", func(t *testing.T) {
@@ -451,12 +441,7 @@ func TestPlaybooks(t *testing.T) {
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
 		resp := testrecorder.Result()
-		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		result, err := ioutil.ReadAll(resp.Body)
-
-		require.NoError(t, err)
-		assert.Equal(t, []byte(`{"status": "OK"}`), result)
 	})
 
 	t.Run("update playbook by non-member", func(t *testing.T) {
@@ -514,12 +499,7 @@ func TestPlaybooks(t *testing.T) {
 		handler.ServeHTTP(testrecorder, testreq, "testpluginid")
 
 		resp := testrecorder.Result()
-		defer resp.Body.Close()
 		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-		result, err := ioutil.ReadAll(resp.Body)
-
-		require.NoError(t, err)
-		assert.Equal(t, []byte(`{"status": "OK"}`), result)
 	})
 
 	t.Run("delete playbook by non-member", func(t *testing.T) {

--- a/server/api/playbooks_test.go
+++ b/server/api/playbooks_test.go
@@ -120,7 +120,7 @@ func TestPlaybooks(t *testing.T) {
 
 		resp := testrecorder.Result()
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusCreated, resp.StatusCode)
 	})
 
 	t.Run("get playbook", func(t *testing.T) {
@@ -254,7 +254,7 @@ func TestPlaybooks(t *testing.T) {
 
 		resp := testrecorder.Result()
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 		result, err := ioutil.ReadAll(resp.Body)
 
 		require.NoError(t, err)
@@ -515,7 +515,7 @@ func TestPlaybooks(t *testing.T) {
 
 		resp := testrecorder.Result()
 		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 		result, err := ioutil.ReadAll(resp.Body)
 
 		require.NoError(t, err)
@@ -704,74 +704,84 @@ func TestSortingPlaybooks(t *testing.T) {
 	}
 
 	testData := []struct {
-		testName      string
-		sortField     string
-		sortDirection string
-		expectedList  []playbook.Playbook
-		expectedErr   error
+		testName           string
+		sortField          string
+		sortDirection      string
+		expectedList       []playbook.Playbook
+		expectedErr        error
+		expectedStatusCode int
 	}{
 		{
-			testName:      "get playbooks with invalid sort field",
-			sortField:     "test",
-			sortDirection: "",
-			expectedList:  nil,
-			expectedErr:   errors.New("bad parameter 'sort' (test)"),
+			testName:           "get playbooks with invalid sort field",
+			sortField:          "test",
+			sortDirection:      "",
+			expectedList:       nil,
+			expectedErr:        errors.New("bad parameter 'sort' (test)"),
+			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
-			testName:      "get playbooks with invalid sort direction",
-			sortField:     "",
-			sortDirection: "test",
-			expectedList:  nil,
-			expectedErr:   errors.New("bad parameter 'direction' (test)"),
+			testName:           "get playbooks with invalid sort direction",
+			sortField:          "",
+			sortDirection:      "test",
+			expectedList:       nil,
+			expectedErr:        errors.New("bad parameter 'direction' (test)"),
+			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
-			testName:      "get playbooks with no sort fields",
-			sortField:     "",
-			sortDirection: "",
-			expectedList:  []playbook.Playbook{playbooktest1, playbooktest2, playbooktest3},
-			expectedErr:   nil,
+			testName:           "get playbooks with no sort fields",
+			sortField:          "",
+			sortDirection:      "",
+			expectedList:       []playbook.Playbook{playbooktest1, playbooktest2, playbooktest3},
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
-			testName:      "get playbooks with sort=title direction=asc",
-			sortField:     "title",
-			sortDirection: "asc",
-			expectedList:  []playbook.Playbook{playbooktest1, playbooktest2, playbooktest3},
-			expectedErr:   nil,
+			testName:           "get playbooks with sort=title direction=asc",
+			sortField:          "title",
+			sortDirection:      "asc",
+			expectedList:       []playbook.Playbook{playbooktest1, playbooktest2, playbooktest3},
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
-			testName:      "get playbooks with sort=title direction=desc",
-			sortField:     "title",
-			sortDirection: "desc",
-			expectedList:  []playbook.Playbook{playbooktest3, playbooktest2, playbooktest1},
-			expectedErr:   nil,
+			testName:           "get playbooks with sort=title direction=desc",
+			sortField:          "title",
+			sortDirection:      "desc",
+			expectedList:       []playbook.Playbook{playbooktest3, playbooktest2, playbooktest1},
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
-			testName:      "get playbooks with sort=stages direction=asc",
-			sortField:     "stages",
-			sortDirection: "asc",
-			expectedList:  []playbook.Playbook{playbooktest1, playbooktest2, playbooktest3},
-			expectedErr:   nil,
+			testName:           "get playbooks with sort=stages direction=asc",
+			sortField:          "stages",
+			sortDirection:      "asc",
+			expectedList:       []playbook.Playbook{playbooktest1, playbooktest2, playbooktest3},
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
-			testName:      "get playbooks with sort=stages direction=desc",
-			sortField:     "stages",
-			sortDirection: "desc",
-			expectedList:  []playbook.Playbook{playbooktest3, playbooktest2, playbooktest1},
-			expectedErr:   nil,
+			testName:           "get playbooks with sort=stages direction=desc",
+			sortField:          "stages",
+			sortDirection:      "desc",
+			expectedList:       []playbook.Playbook{playbooktest3, playbooktest2, playbooktest1},
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
-			testName:      "get playbooks with sort=steps direction=asc",
-			sortField:     "steps",
-			sortDirection: "asc",
-			expectedList:  []playbook.Playbook{playbooktest1, playbooktest2, playbooktest3},
-			expectedErr:   nil,
+			testName:           "get playbooks with sort=steps direction=asc",
+			sortField:          "steps",
+			sortDirection:      "asc",
+			expectedList:       []playbook.Playbook{playbooktest1, playbooktest2, playbooktest3},
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
-			testName:      "get playbooks with sort=steps direction=desc",
-			sortField:     "steps",
-			sortDirection: "desc",
-			expectedList:  []playbook.Playbook{playbooktest3, playbooktest2, playbooktest1},
-			expectedErr:   nil,
+			testName:           "get playbooks with sort=steps direction=desc",
+			sortField:          "steps",
+			sortDirection:      "desc",
+			expectedList:       []playbook.Playbook{playbooktest3, playbooktest2, playbooktest1},
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 	}
 
@@ -816,15 +826,14 @@ func TestSortingPlaybooks(t *testing.T) {
 			resp := testrecorder.Result()
 			defer resp.Body.Close()
 
+			assert.Equal(t, data.expectedStatusCode, resp.StatusCode)
 			if data.expectedErr == nil {
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
 				result, err := ioutil.ReadAll(resp.Body)
 				assert.NoError(t, err)
 				playbooksBytes, err := json.Marshal(&playbookResult)
 				require.NoError(t, err)
 				assert.Equal(t, playbooksBytes, result)
 			} else {
-				assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 				result, err := ioutil.ReadAll(resp.Body)
 				assert.NoError(t, err)
 
@@ -879,26 +888,29 @@ func TestPagingPlaybooks(t *testing.T) {
 	}
 
 	testData := []struct {
-		testName       string
-		page           string
-		perPage        string
-		expectedResult playbook.GetPlaybooksResults
-		emptyStore     bool
-		expectedErr    error
+		testName           string
+		page               string
+		perPage            string
+		expectedResult     playbook.GetPlaybooksResults
+		emptyStore         bool
+		expectedErr        error
+		expectedStatusCode int
 	}{
 		{
-			testName:       "get playbooks with invalid page values",
-			page:           "test",
-			perPage:        "test",
-			expectedResult: playbook.GetPlaybooksResults{},
-			expectedErr:    errors.New("bad parameter"),
+			testName:           "get playbooks with invalid page values",
+			page:               "test",
+			perPage:            "test",
+			expectedResult:     playbook.GetPlaybooksResults{},
+			expectedErr:        errors.New("bad parameter"),
+			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
-			testName:       "get playbooks with negative page values",
-			page:           "-1",
-			perPage:        "-1",
-			expectedResult: playbook.GetPlaybooksResults{},
-			expectedErr:    errors.New("bad parameter"),
+			testName:           "get playbooks with negative page values",
+			page:               "-1",
+			perPage:            "-1",
+			expectedResult:     playbook.GetPlaybooksResults{},
+			expectedErr:        errors.New("bad parameter"),
+			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
 			testName: "get playbooks with page=0 per_page=0 with empty store",
@@ -910,8 +922,9 @@ func TestPagingPlaybooks(t *testing.T) {
 				HasMore:    false,
 				Items:      []playbook.Playbook{},
 			},
-			emptyStore:  true,
-			expectedErr: nil,
+			emptyStore:         true,
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
 			testName: "get playbooks with page=1 per_page=1 with empty store",
@@ -923,8 +936,9 @@ func TestPagingPlaybooks(t *testing.T) {
 				HasMore:    false,
 				Items:      []playbook.Playbook{},
 			},
-			emptyStore:  true,
-			expectedErr: nil,
+			emptyStore:         true,
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
 			testName: "get playbooks with page=0 per_page=0",
@@ -936,7 +950,8 @@ func TestPagingPlaybooks(t *testing.T) {
 				HasMore:    false,
 				Items:      []playbook.Playbook{playbooktest1, playbooktest2, playbooktest3},
 			},
-			expectedErr: nil,
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
 			testName: "get playbooks with page=0 per_page=3",
@@ -948,7 +963,8 @@ func TestPagingPlaybooks(t *testing.T) {
 				HasMore:    false,
 				Items:      []playbook.Playbook{playbooktest1, playbooktest2, playbooktest3},
 			},
-			expectedErr: nil,
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
 			testName: "get playbooks with page=0 per_page=2",
@@ -960,7 +976,8 @@ func TestPagingPlaybooks(t *testing.T) {
 				HasMore:    true,
 				Items:      []playbook.Playbook{playbooktest1, playbooktest2},
 			},
-			expectedErr: nil,
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
 			testName: "get playbooks with page=1 per_page=2",
@@ -972,7 +989,8 @@ func TestPagingPlaybooks(t *testing.T) {
 				HasMore:    false,
 				Items:      []playbook.Playbook{playbooktest3},
 			},
-			expectedErr: nil,
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
 			testName: "get playbooks with page=2 per_page=2",
@@ -984,7 +1002,8 @@ func TestPagingPlaybooks(t *testing.T) {
 				HasMore:    false,
 				Items:      []playbook.Playbook{},
 			},
-			expectedErr: nil,
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 		{
 			testName: "get playbooks with page=9999 per_page=2",
@@ -996,7 +1015,8 @@ func TestPagingPlaybooks(t *testing.T) {
 				HasMore:    false,
 				Items:      []playbook.Playbook{},
 			},
-			expectedErr: nil,
+			expectedErr:        nil,
+			expectedStatusCode: http.StatusOK,
 		},
 	}
 
@@ -1029,14 +1049,13 @@ func TestPagingPlaybooks(t *testing.T) {
 			resp := testrecorder.Result()
 			defer resp.Body.Close()
 
+			assert.Equal(t, data.expectedStatusCode, resp.StatusCode)
 			if data.expectedErr == nil {
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
 				actualList := playbook.GetPlaybooksResults{}
 				err = json.NewDecoder(resp.Body).Decode(&actualList)
 				require.NoError(t, err)
 				assert.Equal(t, data.expectedResult, actualList)
 			} else {
-				assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 				result, err := ioutil.ReadAll(resp.Body)
 				assert.NoError(t, err)
 

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -151,6 +151,9 @@ var ErrIncidentNotActive = errors.New("incident not active")
 // ErrIncidentActive is used to indicate trying to run a command on an incident that is active.
 var ErrIncidentActive = errors.New("incident active")
 
+// ErrMalformedIncident is used to indicate an incident is not valid
+var ErrMalformedIncident = errors.New("incident active")
+
 // Service is the incident/service interface.
 type Service interface {
 	// GetIncidents returns filtered incidents and the total count before paging.

--- a/tests-e2e/cypress/support/plugin_api_commands.js
+++ b/tests-e2e/cypress/support/plugin_api_commands.js
@@ -81,7 +81,7 @@ Cypress.Commands.add('apiStartIncident', ({teamId, playbookId, incidentName, com
             playbook_id: playbookId,
         },
     }).then((response) => {
-        expect(response.status).to.equal(200);
+        expect(response.status).to.equal(201);
         cy.wrap(response.body);
     });
 });
@@ -179,7 +179,7 @@ Cypress.Commands.add('apiCreatePlaybook', ({teamId, title, createPublicIncident,
             member_ids: memberIDs,
         },
     }).then((response) => {
-        expect(response.status).to.equal(200);
+        expect(response.status).to.equal(201);
         cy.wrap(response.body);
     });
 });


### PR DESCRIPTION
#### Summary

This PR standardizes the HTTP status codes returned by the API. The changes affect only the API layer (I tried at first to modify all the layers: API, service and store; but I'd like us to decide together how to approach this). There are a few things more that we can do to standardize, as checking empty IDs as the first step of the data validation in the API, but I also left those for the data validation approach we follow.

The main changes are:
- Returning 400 (Bad Request) instead of 500 (Internal Server Error) when it is clear in the API layer that the data is not valid. This happens when the query parameters or the body values are not valid.
- Returning 403 (Forbidden) instead of 500 (Internal Server Error) when there is a permissions error.
- Returning 201 (Created) instead of 200 (OK) when creating an entity. In these cases, I've also added a Location header with the URL of the created entity, as per the documentation.
- Returning 204 (No Content) instead of 200 (OK) when deleting an entity.

I've made a few more changes:
- I've removed the returned body ``w.Write([]byte(`{"status": "OK"}`))``, which was used inconsistently, and which was completely ignored in the client side.
- I've changed a bunch of repeated code just by using the `ReturnJSON` function.

One thing I was not able to do was to add `w.Header().Set("Content-Type", "application/json")` to the `ReturnJSON` function. This header was used only in a couple of places, but I thought it would be nice to have it in all JSON-encoded responses. However, the E2E tests failed when trying to parse the response when this header was added, as the body was encoded as a quoted string (?). Surprisingly, this happened in CI, but not locally. I think I must be missing something very basic here, but I decided to go without it for now, as it does not change current behaviour. We can discuss it later.

##### Detailed changes
<details>
<summary>Click on the arrow to read the detailed notes I took when doing this. They are unprocessed, so maybe not very useful for anybody else, but I'll leave them here for the sake of self-containment.</summary>

- GET /incidents: getIncidents
  + Nothing done
- POST /incidents: createIncidentFromPost
  + CHANGED: Return 400 instead of 500 when unable to decode incident
  + CHANGED: Return 400 instead of 500 when any of the params is not valid
  + CHANGED: Return 403 instead of 500 when the commander does not have permissions for the team
  + ADDED: Return location
  + CHANGED: Return 201 instead of 200 when the incident is created
- POST /incidents/dialog: createIncidentFromDialog
  + CHANGED: Return 400 instead of 500 when unable to decode dialog request
  + CHANGED: Return 400 instead of 500 when unable to unmarshal dialog state
  + CHANGED: Return 400 instead of 500 when any of the params is not valid
  + NOT CHANGED: the permission error (that should return a 404) is handled with a submitDialogResponse. Did not know what to do here.
  + ADDED: Return location
  + CHANGED: Return 201 instead of 200 when the incident is created
- GET /incidents/commanders: getCommanders
  - Already has data validation and permission
- GET /incidents/channels: getChannels
  - Already has data validation and permission
- GET /incidents/checklist-autocomplete: getChecklistAutocomplete
  + Nothing done
- GET /incidents/[id]: getIncident
  + Nothing done
- GET /incidents/[id]/metadata: getIncidentMetadata
  + Nothing done
- PATCH /incidents/[id]: updateIncident
  + CHANGED: Return 400 when the options cannot be decoded
- PUT POST /incidents/[id]/end: endIncident
  + Nothing done
- PUT /incidents/[id]/restart: restartIncident
  + Nothing done
- POST /incidents/[id]/commander: changeCommander
  + CHANGED: Return 400 instead of 500 when parsing of params fails
- POST /incidents/[id]/next-stage-dialog: nextStageDialog
  + CHANGED: Return 400 instead of 500 when dialog request cannot be decoded
  + CHANGED: Return 400 instead of 500 when state cannot be parsed
- GET /incidents/channel/[id]: getIncidentByChannel
  + Already: If no permissions, return 404
  + Already: if not found by the service, return 404
- PUT /incidents/checklists/[id]/add: addChecklistItem
  + CHANGED: Return 400 instead of 500 when query param cannot be parsed
  + CHANGED: Return 400 instead of 500 when body cannot be parsed
  + CHANGED: Return 201 instead of 200 when the item is added
- PUT /incidents/checklists/[id]/reorder: reorderChecklist
  + CHANGED: Return 400 instead of 500 when query param cannot be parsed
  + CHANGED: Return 400 instead of 500 when body cannot be parsed
- DELETE /incidents/checklists/[id]/item/[id]: itemDelete
  + CHANGED: Return 400 instead of 500 when any of the query params cannot be parsed
  + CHANGED: Return 204 instead of 200 when item is succesfully deleted
- PUT /incidents/checklists/[id]/item/[id]: itemRename
  + CHANGED: Return 400 instead of 500 when any of the query params cannot be parsed
  + CHANGED: Return 400 instead of 500 when the body cannot be decoded
- PUT /incidents/checklists/[id]/item/[id]/state: itemSetState
  + CHANGED: Return 400 instead of 500 when any of the query params cannot be parsed
  + CHANGED: Return 400 instead of 500 when the body cannot be decoded
  + CHANGED: Return 400 instead of 500 when the new checklist item state is not valid
- PUT /incidents/checklists/[id]/item/[id]/assignee: itemSetAssignee
  + CHANGED: Return 400 instead of 500 when any of the query params cannot be parsed
  + CHANGED: Return 400 instead of 500 when the body cannot be decoded
- POST /incidents/checklists/[id]/item/[id]/run: itemRun
  + CHANGED: Return 400 instead of 500 when any of the query params cannot be parsed
- POST /playbooks: createPlaybook
  + CHANGED: Return 400 instead of 500 when the body cannot be decoded
  + It already returns 403 when there is a permissions error
  + CHANGED: Return 201 instead of 200 when the playbook is succesfully created
  + ADDED: Return Location with the URL of the new entity
- GET /playbooks: getPlaybooks
  + CHANGED: Return 400 instead of 500 when the options are not valid
  + It already returns 403 when there is a permissions error
- GET /playbooks/[id]: getPlaybook
  + It already returns 403 when there is a permissions error.
- PUT /playbooks/[id]: updatePlaybook
  + CHANGED: Return 400 instead of 500 when the body cannot be decoded
  + It already returns 403 when there is a permissions error.
- DELETE /playbooks/[id]: deletePlaybook
  + It already returns 403 when there is a permissions error
  + CHANGED: Return 204 instead of 200 when the playbook is successfully deleted

</details>

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26194
