### PR TITLE
MM-29886 - Fix for createIncidentFromDialog allows creating incidents in arbitrary teams

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -166,9 +166,16 @@ func (h *IncidentHandler) updateIncident(w http.ResponseWriter, r *http.Request)
 // createIncidentFromDialog handles the interactive dialog submission when a user presses confirm on
 // the create incident dialog.
 func (h *IncidentHandler) createIncidentFromDialog(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("Mattermost-User-ID")
+
 	request := model.SubmitDialogRequestFromJson(r.Body)
 	if request == nil {
 		HandleErrorWithCode(w, http.StatusBadRequest, "failed to decode SubmitDialogRequest", nil)
+		return
+	}
+
+	if userID != request.UserId {
+		HandleErrorWithCode(w, http.StatusBadRequest, "interactive dialog's userID must be the same as the requester's userID", nil)
 		return
 	}
 


### PR DESCRIPTION
#### Summary
- Check that the dialog's userID is the same as the requester's
- Thanks Juho!

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-29886