### PR TITLE
MM-29887 - Fix for: autocomplete allows read access to all checklist items in all incidents

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -571,9 +571,17 @@ func (h *IncidentHandler) nextStageDialog(w http.ResponseWriter, r *http.Request
 // getChecklistAutocomplete handles the GET /incidents/checklists-autocomplete api endpoint
 func (h *IncidentHandler) getChecklistAutocomplete(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	incidentID, err := h.incidentService.GetIncidentIDForChannel(query.Get("channel_id"))
+	channelID := query.Get("channel_id")
+	userID := r.Header.Get("Mattermost-User-ID")
+
+	incidentID, err := h.incidentService.GetIncidentIDForChannel(channelID)
 	if err != nil {
 		HandleError(w, err)
+		return
+	}
+
+	if err = permissions.ViewIncident(userID, incidentID, h.pluginAPI, h.incidentService); err != nil {
+		HandleErrorWithCode(w, http.StatusForbidden, "user does not have permissions", nil)
 		return
 	}
 


### PR DESCRIPTION
#### Summary
- Add permissions check to autocomplete calls; test
- It's okay to return an error, the server's autocomplete code will display an empty list
- Thank again Juho

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-29887
