### PR TITLE
MM-29897 - Fix for: /incident announce allows announcing to arbitrary channels

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -360,8 +360,8 @@ func (r *Runner) actionAnnounce(args []string) {
 			r.postCommandResponse("Channel not found: " + channelarg)
 			continue
 		}
-		if !permissions.MemberOfChannelID(r.args.UserId, targetChannel.Id, r.pluginAPI) {
-			r.postCommandResponse("Not a member of: " + channelarg)
+		if !permissions.CanPostToChannel(r.args.UserId, targetChannel.Id, r.pluginAPI) {
+			r.postCommandResponse("Cannot post to: " + channelarg)
 			continue
 		}
 		if err := r.announceChannel(targetChannel.Id, commanderUser.Username, incidentChannel.Name); err != nil {

--- a/server/permissions/permissions.go
+++ b/server/permissions/permissions.go
@@ -94,3 +94,7 @@ func IsAdmin(userID string, pluginAPI *pluginapi.Client) bool {
 func MemberOfChannelID(userID, channelID string, pluginAPI *pluginapi.Client) bool {
 	return pluginAPI.User.HasPermissionToChannel(userID, channelID, model.PERMISSION_READ_CHANNEL)
 }
+
+func CanPostToChannel(userID, channelID string, pluginAPI *pluginapi.Client) bool {
+	return pluginAPI.User.HasPermissionToChannel(userID, channelID, model.PERMISSION_CREATE_POST)
+}

--- a/server/permissions/permissions.go
+++ b/server/permissions/permissions.go
@@ -90,3 +90,7 @@ func CanViewTeam(userID, teamID string, pluginAPI *pluginapi.Client) bool {
 func IsAdmin(userID string, pluginAPI *pluginapi.Client) bool {
 	return pluginAPI.User.HasPermissionTo(userID, model.PERMISSION_MANAGE_SYSTEM)
 }
+
+func MemberOfChannelID(userID, channelID string, pluginAPI *pluginapi.Client) bool {
+	return pluginAPI.User.HasPermissionToChannel(userID, channelID, model.PERMISSION_READ_CHANNEL)
+}


### PR DESCRIPTION
#### Summary
- Check permissions before posting in an arbitrary channel

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-29897
